### PR TITLE
Adjust ENT harvest workflow to use previous month directories

### DIFF
--- a/.github/workflows/ent-harvest.yml
+++ b/.github/workflows/ent-harvest.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Organize outputs by month
         run: |
-          OUT_DIR=$(date -u +'%Y/%m')
+          OUT_DIR=$(date -u -d '1 month ago' +'%Y/%m')
           echo "OUT_DIR=$OUT_DIR" >> $GITHUB_ENV
           mkdir -p "$OUT_DIR"
 
@@ -53,7 +53,7 @@ jobs:
           git config user.name  "ent-bot"
           git config user.email "ent-bot@users.noreply.github.com"
 
-          git add "$OUT_DIR"
+          git add "${OUT_DIR}"
           git add -u
 
           git commit -m "ENT harvest: $(date -u +'%Y-%m-%dT%H:%M:%SZ')" || echo "Nothing to commit"


### PR DESCRIPTION
## Summary
- compute the ENT harvest output directory using the previous UTC month so it aligns with the notebook logic
- continue exporting the directory to the workflow environment and reuse it for committing harvested artifacts

## Testing
- Simulated the workflow step in a temporary directory to confirm ent_raw_results.csv, ent_all_results.json, and articlesRetrieval.out.ipynb land in the same YYYY/MM folder


------
https://chatgpt.com/codex/tasks/task_e_68dce119d1488328ba5e55302c2ff222