### PR TITLE
Restyle card deck as playing cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -365,6 +365,14 @@ function renderCardDeck() {
     const month = formatMonthShort(session.dateObj);
     const year = session.year != null ? String(session.year) : "";
 
+    card.dataset.day = day;
+    card.dataset.month = month;
+    card.dataset.year = year;
+    const ariaBits = [title];
+    if (journal) ariaBits.push(journal);
+    ariaBits.push(`${day} ${month}${year ? ` ${year}` : ""}`.trim());
+    card.setAttribute("aria-label", ariaBits.join(", "));
+
     card.innerHTML = `
       <div class="playing-card-inner">
         <header class="playing-card-header">

--- a/style.css
+++ b/style.css
@@ -489,59 +489,108 @@ body {
 .card-deck-view {
   margin-top: 0.5rem;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1.25rem;
+  justify-items: center;
 }
 
 .playing-card {
   position: relative;
-  background:
-    radial-gradient(circle at 0 0, var(--accent-soft), transparent 55%),
-    radial-gradient(circle at 100% 100%, rgba(37, 99, 235, 0.16), transparent 55%),
-    var(--bg-elevated);
+  width: 100%;
+  max-width: 230px;
+  aspect-ratio: 2 / 3;
+  padding: 1.35rem 1.1rem;
   border-radius: 22px;
-  padding: 0.85rem 0.9rem;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  box-shadow: var(--shadow-subtle);
-  color: var(--text);
+  background: radial-gradient(circle at 50% 20%, rgba(37, 99, 235, 0.08), transparent 60%),
+    linear-gradient(160deg, #ffffff 0%, #f4f7ff 45%, #ffffff 100%);
+  border: 1.5px solid rgba(15, 23, 42, 0.12);
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.18), inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  color: #0f172a;
   transform-origin: center;
   opacity: 0;
   animation: fadeInUp 0.35s ease forwards;
-  transition: transform 0.16s ease, box-shadow 0.16s ease,
-    border-color 0.16s ease, background 0.16s ease;
-  aspect-ratio: 2 / 3;
+  transition: transform 0.18s ease, box-shadow 0.18s ease,
+    border-color 0.18s ease, background 0.18s ease;
+  overflow: hidden;
+  --card-muted: #475569;
+  --card-corner: #dc2626;
+}
+
+.playing-card::before,
+.playing-card::after {
+  content: attr(data-day) "\A" attr(data-month);
+  white-space: pre;
+  position: absolute;
+  font-weight: 700;
+  font-size: 0.82rem;
+  line-height: 1.05;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--card-corner);
+  pointer-events: none;
+}
+
+.playing-card::before {
+  top: 0.75rem;
+  left: 0.85rem;
+  text-align: left;
+}
+
+.playing-card::after {
+  bottom: 0.75rem;
+  right: 0.85rem;
+  transform: rotate(180deg);
+  text-align: left;
 }
 
 .playing-card:hover {
-  transform: translateY(-4px) rotate(-1deg);
-  box-shadow: var(--shadow-soft);
-  border-color: rgba(37, 99, 235, 0.55);
+  transform: translateY(-6px) rotate(-1.5deg);
+  box-shadow: 0 30px 48px rgba(15, 23, 42, 0.24);
+  border-color: rgba(37, 99, 235, 0.45);
 }
 
 .playing-card-inner {
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  align-items: center;
+  text-align: center;
   height: 100%;
-  gap: 0.45rem;
+  gap: 0.65rem;
 }
 
 .playing-card-header {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  font-size: 0.72rem;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: var(--text-softer);
+  justify-content: center;
+  align-items: center;
+  width: 100%;
 }
 
 .playing-card-date {
-  font-weight: 500;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .playing-card-year {
-  opacity: 0.85;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.7rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--card-muted);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: rgba(15, 23, 42, 0.04);
 }
 
 .playing-card-body {
@@ -549,34 +598,59 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 0.3rem;
+  align-items: center;
+  gap: 0.45rem;
 }
 
 .playing-card-title {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 1rem;
   font-weight: 600;
+  line-height: 1.35;
 }
 
 .playing-card-journal {
   margin: 0;
-  font-size: 0.78rem;
-  color: var(--text-soft);
+  font-size: 0.8rem;
+  color: var(--card-muted);
 }
 
 .playing-card-footer {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   font-size: 0.74rem;
-  color: var(--text-softer);
+  color: var(--card-muted);
+  width: 100%;
 }
 
 .playing-card-meta {
-  padding: 0.15rem 0.5rem;
+  padding: 0.25rem 0.7rem;
   border-radius: var(--radius-pill);
-  border: 1px solid rgba(148, 163, 184, 0.6);
-  background: rgba(15, 23, 42, 0.02);
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  background: rgba(15, 23, 42, 0.06);
+}
+
+:root[data-theme="dark"] .card-deck-view {
+  gap: 1.1rem;
+}
+
+:root[data-theme="dark"] .playing-card {
+  background: linear-gradient(150deg, #f8fafc 0%, #e2e8f0 50%, #f8fafc 100%);
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 26px 42px rgba(15, 23, 42, 0.55), inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+:root[data-theme="dark"] .playing-card-year {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  color: #1f2937;
+}
+
+:root[data-theme="dark"] .playing-card-meta {
+  border-color: rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.18);
+  color: #1f2937;
 }
 
 .session-card {


### PR DESCRIPTION
## Summary
- redesign the card deck view styles so cards mirror traditional playing card proportions and decoration
- add screen-reader labels and expose date metadata for each card to drive the new visuals

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917829568ec83289ae0665d0c8733a9)