### PR TITLE
Run populate sessions after ENT harvest

### DIFF
--- a/.github/workflows/populate-sessions.yml
+++ b/.github/workflows/populate-sessions.yml
@@ -2,10 +2,15 @@ name: Populate sessions
 
 on:
   workflow_dispatch: {}  # allow manual runs
+  workflow_run:
+    workflows: ["ENT harvest (stage 1–2)"]
+    types:
+      - completed
 
 jobs:
   populate:
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- add workflow_run trigger to populate sessions when ENT harvest completes successfully
- retain manual dispatch and existing population steps

## Testing
- not run (CI workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1d319da88328b710f03174d0ea71)