### PR TITLE
Aggregate ent results when populating sessions

### DIFF
--- a/populate_sessions.py
+++ b/populate_sessions.py
@@ -1,23 +1,101 @@
-import json
 import csv
-from pathlib import Path
+import json
 from datetime import datetime
+from pathlib import Path
 
-def find_latest_ent_file(root: Path) -> Path | None:
-    candidates = sorted(root.rglob("ent_all_results.json"))
-    return candidates[-1] if candidates else None
+
+def load_ent_index(root: Path) -> dict[str, dict]:
+    """Index all ent_all_results.json files by PMID."""
+
+    index: dict[str, dict] = {}
+    for year_dir in root.glob("20[0-9][0-9]"):
+        if not year_dir.is_dir():
+            continue
+        for month_dir in year_dir.glob("[01][0-9]"):
+            jf = month_dir / "ent_all_results.json"
+            if jf.is_file():
+                articles = json.loads(jf.read_text(encoding="utf-8"))
+                for art in articles:
+                    pmid = str(art.get("PMID", "")).strip()
+                    if pmid and pmid not in index:
+                        index[pmid] = art
+    return index
+
+
+def load_manual_sessions(sessions_path: Path) -> dict[str, dict]:
+    """Load existing sessions.csv and index by PMID."""
+
+    if not sessions_path.is_file():
+        return {}
+
+    manual: dict[str, dict] = {}
+    with sessions_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            pmid = str(row.get("pmid", "")).strip()
+            if pmid:
+                manual[pmid] = row
+    return manual
+
+
+def normalize_date(date_str: str) -> str:
+    """Normalize publication or curated dates to ISO format when possible."""
+
+    date_str = (date_str or "").strip()
+    if not date_str:
+        return ""
+    try:
+        dt = datetime.strptime(date_str, "%Y-%b-%d")
+    except Exception:
+        try:
+            dt = datetime.fromisoformat(date_str)
+        except Exception:
+            return date_str
+    return dt.date().isoformat()
+
+
+def build_session_row(pmid: str, art: dict | None, manual: dict | None) -> list:
+    art = art or {}
+    manual = manual or {}
+
+    date_str = manual.get("date") or art.get("Publication_Date", "")
+    title = manual.get("title") or art.get("Title", "")
+    journal = manual.get("journal") or art.get("Journal", "")
+    authors = manual.get("authors") or art.get("Authors", "")
+    doi = manual.get("doi") or art.get("DOI", "")
+    abstract = manual.get("abstract") or art.get("Abstract", "")
+    pdf = manual.get("pdf", "") or (f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/" if pmid else "")
+
+    return [
+        normalize_date(date_str),
+        manual.get("presenter", ""),
+        pmid,
+        title,
+        journal,
+        authors,
+        doi,
+        abstract,
+        manual.get("notes", ""),
+        pdf,
+    ]
+
 
 def main():
     repo_root = Path(__file__).parent
-    ent_file = find_latest_ent_file(repo_root)
-    if not ent_file:
-        raise SystemExit("No ent_all_results.json files found")
-
-    with ent_file.open(encoding="utf-8") as f:
-        articles = json.load(f)
-
-    # Write sessions.csv in repo root
+    ent_index = load_ent_index(repo_root)
     sessions_path = repo_root / "sessions.csv"
+    manual_sessions = load_manual_sessions(sessions_path)
+
+    all_pmids = set(ent_index) | set(manual_sessions)
+    rows = []
+    for pmid in all_pmids:
+        art = ent_index.get(pmid)
+        manual = manual_sessions.get(pmid)
+        rows.append(build_session_row(pmid, art, manual))
+
+    # Sort newest first by normalized date string
+    rows.sort(key=lambda r: r[0], reverse=True)
+
     with sessions_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(
@@ -34,29 +112,12 @@ def main():
                 "pdf",
             ]
         )
-        for art in articles:
-            pub_date = art.get("Publication_Date", "")
-            try:
-                dt = datetime.strptime(pub_date, "%Y-%b-%d")
-                iso_date = dt.strftime("%Y-%m-%d")
-            except Exception:
-                iso_date = pub_date
-            writer.writerow(
-                [
-                    iso_date,
-                    "",
-                    art.get("PMID", ""),
-                    art.get("Title", ""),
-                    art.get("Journal", ""),
-                    art.get("Authors", ""),
-                    art.get("DOI", ""),
-                    art.get("Abstract", ""),
-                    "",
-                    "",
-                ]
-            )
+        writer.writerows(rows)
 
-    print(f"Wrote {len(articles)} rows to {sessions_path} from {ent_file}")
+    print(
+        f"Wrote {len(rows)} unique PMIDs to {sessions_path} using ent_all_results.json files across the repo"
+    )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- index ent_all_results.json files across year/month directories to aggregate PMIDs
- merge deduplicated ent metadata with any curated session fields before rewriting sessions.csv
- normalize dates and preserve pubmed fallback links for entries without custom PDFs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff9c114b8832883bb7162bc4aa2b0)