### PR TITLE
Increase focused card enlargement

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,6 +92,11 @@ function attachEventHandlers() {
   }
 
   window.addEventListener("scroll", handleScroll);
+  window.addEventListener("resize", () => {
+    if (focusedCard) {
+      updateCardFocusTransform(focusedCard);
+    }
+  });
 }
 
 function handleScroll() {
@@ -507,6 +512,7 @@ function enterCardFocus(card) {
     focusedCard.classList.remove("is-focused");
   }
 
+  updateCardFocusTransform(card);
   focusedCard = card;
   card.classList.add("is-focused");
   document.body.classList.add("card-focus-active");
@@ -519,6 +525,9 @@ function enterCardFocus(card) {
 function exitCardFocus() {
   if (focusedCard) {
     focusedCard.classList.remove("is-focused");
+    focusedCard.classList.remove("is-flipped");
+    focusedCard.setAttribute("aria-pressed", "false");
+    resetCardFocusTransform(focusedCard);
     focusedCard = null;
   }
 
@@ -530,6 +539,26 @@ function exitCardFocus() {
       cardFocusOverlay.classList.add("hidden");
     }, 180);
   }
+}
+
+function updateCardFocusTransform(card) {
+  const rect = card.getBoundingClientRect();
+  const centerX = window.innerWidth / 2;
+  const centerY = window.innerHeight / 2;
+  const translateX = centerX - (rect.left + rect.width / 2);
+  const translateY = centerY - (rect.top + rect.height / 2);
+  const targetWidth = Math.min(window.innerWidth * 0.82, 420);
+  const scale = Math.min(1.85, Math.max(1.22, targetWidth / rect.width));
+
+  card.style.setProperty("--card-focus-translate-x", `${translateX}px`);
+  card.style.setProperty("--card-focus-translate-y", `${translateY}px`);
+  card.style.setProperty("--card-focus-scale", scale.toFixed(3));
+}
+
+function resetCardFocusTransform(card) {
+  card.style.removeProperty("--card-focus-translate-x");
+  card.style.removeProperty("--card-focus-translate-y");
+  card.style.removeProperty("--card-focus-scale");
 }
 
 /* ---------- Rendering: timeline ---------- */

--- a/style.css
+++ b/style.css
@@ -519,6 +519,9 @@ body.card-focus-active {
 }
 
 .playing-card {
+  --card-focus-translate-x: 0px;
+  --card-focus-translate-y: 0px;
+  --card-focus-scale: 1;
   position: relative;
   width: 100%;
   max-width: 230px;
@@ -526,9 +529,10 @@ body.card-focus-active {
   border-radius: 22px;
   perspective: 1200px;
   transform-origin: center;
+  transform: translate3d(0, 0, 0) scale(1);
   opacity: 0;
   animation: fadeInUp 0.35s ease forwards;
-  transition: transform 0.18s ease, box-shadow 0.18s ease,
+  transition: transform 0.3s ease, box-shadow 0.24s ease,
     border-color 0.18s ease, background 0.18s ease;
   overflow: hidden;
   --card-muted: #475569;
@@ -536,11 +540,8 @@ body.card-focus-active {
 }
 
 .playing-card.is-focused {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  max-width: 360px;
-  transform: translate(-50%, -50%) scale(1.12);
+  transform: translate3d(var(--card-focus-translate-x),
+      var(--card-focus-translate-y), 0) scale(var(--card-focus-scale));
   z-index: 90;
   box-shadow: 0 26px 48px rgba(15, 23, 42, 0.4), 0 0 0 2px rgba(37, 99, 235, 0.5);
 }
@@ -620,6 +621,12 @@ body.card-focus-active {
   transform: translateY(-6px) rotate(-1.5deg);
   box-shadow: 0 30px 48px rgba(15, 23, 42, 0.24);
   border-color: rgba(37, 99, 235, 0.45);
+}
+
+.playing-card.is-focused:hover {
+  transform: translate3d(var(--card-focus-translate-x),
+      var(--card-focus-translate-y), 0) scale(var(--card-focus-scale));
+  box-shadow: 0 26px 48px rgba(15, 23, 42, 0.4), 0 0 0 2px rgba(37, 99, 235, 0.5);
 }
 
 .playing-card-header {


### PR DESCRIPTION
## Summary
- increase focused card scale by targeting a larger viewport-relative width before clamping
- retain centering transform while ensuring the focused card visibly enlarges when activated

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693015d185808328a936b1507bbf27a9)