### PR TITLE
Center and enlarge cards on flip

### DIFF
--- a/script.js
+++ b/script.js
@@ -474,17 +474,14 @@ function renderCardDeck() {
       </div>
     `;
 
-    const toggleFlip = () => {
+    const handleCardActivate = () => {
       const isFlipped = card.classList.toggle("is-flipped");
       card.setAttribute("aria-pressed", String(isFlipped));
-    };
 
-    const handleCardActivate = () => {
-      toggleFlip();
-      if (focusedCard === card) {
-        exitCardFocus();
-      } else {
+      if (isFlipped) {
         enterCardFocus(card);
+      } else {
+        exitCardFocus();
       }
     };
 
@@ -548,7 +545,7 @@ function updateCardFocusTransform(card) {
   const translateX = centerX - (rect.left + rect.width / 2);
   const translateY = centerY - (rect.top + rect.height / 2);
   const targetWidth = Math.min(window.innerWidth * 0.82, 420);
-  const scale = Math.min(1.85, Math.max(1.22, targetWidth / rect.width));
+  const scale = Math.min(1.9, Math.max(1.35, targetWidth / rect.width));
 
   card.style.setProperty("--card-focus-translate-x", `${translateX}px`);
   card.style.setProperty("--card-focus-translate-y", `${translateY}px`);


### PR DESCRIPTION
## Summary
- tie card focus/overlay to the flip state so flipped cards center on screen
- increase focused card scale for a clearer enlarged view when flipped

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693125f957ac8328a4a4df4a0aceb340)