### PR TITLE
Center and scale cards when flipped

### DIFF
--- a/script.js
+++ b/script.js
@@ -477,14 +477,16 @@ function renderCardDeck() {
     const toggleFlip = () => {
       const isFlipped = card.classList.toggle("is-flipped");
       card.setAttribute("aria-pressed", String(isFlipped));
+      return isFlipped;
     };
 
     const handleCardActivate = () => {
-      toggleFlip();
-      if (focusedCard === card) {
-        exitCardFocus();
-      } else {
+      const isFlipped = toggleFlip();
+
+      if (isFlipped) {
         enterCardFocus(card);
+      } else {
+        exitCardFocus();
       }
     };
 


### PR DESCRIPTION
## Summary
- ensure card flips trigger the focused state so cards move to the center and scale up
- return the flip status from toggling to drive focus and exit logic

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693125f957ac8328a4a4df4a0aceb340)