### PR TITLE
Center cards when flipped

### DIFF
--- a/script.js
+++ b/script.js
@@ -474,18 +474,20 @@ function renderCardDeck() {
       </div>
     `;
 
-    const toggleFlip = () => {
-      const isFlipped = card.classList.toggle("is-flipped");
-      card.setAttribute("aria-pressed", String(isFlipped));
+    const setCardFlipped = (flipped) => {
+      card.classList.toggle("is-flipped", flipped);
+      card.setAttribute("aria-pressed", String(flipped));
+
+      if (flipped) {
+        enterCardFocus(card);
+      } else {
+        exitCardFocus();
+      }
     };
 
     const handleCardActivate = () => {
-      toggleFlip();
-      if (focusedCard === card) {
-        exitCardFocus();
-      } else {
-        enterCardFocus(card);
-      }
+      const willFlip = !card.classList.contains("is-flipped");
+      setCardFlipped(willFlip);
     };
 
     card.addEventListener("click", (event) => {


### PR DESCRIPTION
## Summary
- ensure playing cards enter focus mode when flipped so they move to center and scale up
- keep accessibility state in sync with the flipped status

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693125f957ac8328a4a4df4a0aceb340)