### PR TITLE
Prevent hover transform overriding focused cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -617,7 +617,7 @@ body.card-focus-active {
   text-align: left;
 }
 
-.playing-card:hover {
+.playing-card:hover:not(.is-focused) {
   transform: translateY(-6px) rotate(-1.5deg);
   box-shadow: 0 30px 48px rgba(15, 23, 42, 0.24);
   border-color: rgba(37, 99, 235, 0.45);


### PR DESCRIPTION
## Summary
- skip the default hover transform for focused playing cards
- keep focused cards using their viewport-centered transform when hovered

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932776f07188328ae7de1e0a6514aa4)