### PR TITLE
Adjust playing card animation for focus transforms

### DIFF
--- a/style.css
+++ b/style.css
@@ -530,8 +530,8 @@ body.card-focus-active {
   perspective: 1200px;
   transform-origin: center;
   transform: translate3d(0, 0, 0) scale(1);
-  opacity: 0;
-  animation: fadeInUp 0.35s ease forwards;
+  opacity: 1;
+  animation: fadeInUp 0.35s ease;
   transition: transform 0.3s ease, box-shadow 0.24s ease,
     border-color 0.18s ease, background 0.18s ease;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- remove the forwards fill from the playing card entrance animation
- allow the focus transform to recenter and scale cards without being pinned by the intro animation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932fa5726188328a23ef6a1342b4189)