### PR TITLE
Enable scrolling on card backs

### DIFF
--- a/style.css
+++ b/style.css
@@ -709,6 +709,24 @@ body.card-focus-active {
   justify-content: flex-start;
   gap: 0.4rem;
   transform: rotateY(180deg);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(15, 23, 42, 0.2) transparent;
+  -webkit-overflow-scrolling: touch;
+}
+
+.playing-card-back::-webkit-scrollbar {
+  width: 8px;
+}
+
+.playing-card-back::-webkit-scrollbar-thumb {
+  background: rgba(15, 23, 42, 0.2);
+  border-radius: 999px;
+}
+
+.playing-card-back::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .playing-card-back-header {


### PR DESCRIPTION
## Summary
- allow the back face of playing cards to scroll when abstracts overflow
- add slim scrollbar styling and touch-friendly scrolling behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932fc4703148328ad361cfe1dda2649)