### PR TITLE
Show full abstracts and justify text

### DIFF
--- a/style.css
+++ b/style.css
@@ -763,6 +763,10 @@ body.card-focus-active {
   text-align: left;
 }
 
+.playing-card-back-abstract {
+  text-align: justify;
+}
+
 .playing-card-back-notes {
   font-weight: 600;
 }
@@ -934,10 +938,7 @@ body.card-focus-active {
   margin: 0.2rem 0 0.2rem;
   font-size: 0.82rem;
   color: var(--text-soft);
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  text-align: justify;
 }
 
 .session-footer {


### PR DESCRIPTION
## Summary
- remove abstract truncation in session cards so full text is visible
- justify abstract text for session list cards and playing card backs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933009ea75483288bbc19bff951f3d9)