### PR TITLE
Fix card deck rendering by defining subject chip markup

### DIFF
--- a/script.js
+++ b/script.js
@@ -430,6 +430,7 @@ function renderCardDeck() {
     const day = formatDay(session.dateObj);
     const month = formatMonthShort(session.dateObj);
     const year = session.year != null ? String(session.year) : "";
+    const subjectsMarkup = renderSubjectChips(session.subjects);
 
     card.dataset.day = day;
     card.dataset.month = month;


### PR DESCRIPTION
## Summary
- define subject chip markup before rendering playing card templates
- restore card deck rendering now that subjects markup is available

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69369983edb88328acff98ba34051ece)