### PR TITLE
Add heuristic tagging and subject summaries for recent sessions

### DIFF
--- a/SUBJECTS.md
+++ b/SUBJECTS.md
@@ -1,0 +1,35 @@
+# Subject tagging for recent publications
+
+The `tag_subjects.py` helper applies lightweight keyword heuristics to all journal club entries (currently September–November 2025) and stores subject tags alongside each session.
+
+## Subject heuristics
+- **Rhinology & Allergy**: rhino, sinus, nasal/nose, septum, polyps, olfaction/smell, sinonasal, nasopharynx, epistaxis
+- **Otology & Neurotology**: cochlea, ear, otic, tympanic/mastoid, ossicular, vestibular, tinnitus, hearing, eustachian
+- **Audiology & Hearing Science**: audiology/audiogram, speech perception, listening, hearing aids, cochlear implants
+- **Laryngology & Voice**: larynx, vocal cords, voice, phonation, glottis, dysphonia, esophageal topics
+- **Airway & Trachea**: airway, trachea, bronchi, intubation/decannulation, stents
+- **Sleep Medicine**: sleep, apnea/OSA, hypopnea, CPAP
+- **Head & Neck Oncology**: carcinoma, cancer, tumor/neoplasm, sarcoma, oncology, malignant, papilloma
+- **Endocrine (Thyroid/Parathyroid)**: thyroid, parathyroid, endocrine
+- **Salivary & Oral Cavity**: salivary glands, parotid, submandibular/sublingual, sialo-, oral cavity/tongue/palate/tonsil
+- **Facial Plastics & Reconstruction**: facial plastics, reconstruction, rhinoplasty, cleft, aesthetic/cosmetic, flap/graft/scar
+- **Skull Base & Cranial**: skull base, cranial/intracranial, cerebrospinal/CSF, pituitary, meningioma
+- **Trauma**: trauma, fracture, injury, gunshot, laceration
+- **Infectious Disease**: infection, viral, bacterial, fungal, abscess, mycobacterial, sepsis
+- **Pediatrics (overlay tag)**: pediatric, child/children, infant, neonate/newborn, adolescent, toddler
+- **General ENT/Other**: fallback when no other rule matches
+
+## Running the tagger
+
+```bash
+python tag_subjects.py
+```
+
+The script rewrites `data/journal_club.json` with updated `subjects` arrays and generates `data/subject_summary.json`, which aggregates subject counts by month.
+
+## Common subjects in the past few months
+
+Based on `data/subject_summary.json`, the most frequent subjects were:
+- **September 2025**: Laryngology & Voice (183), General ENT/Other (162), Otology & Neurotology (133), Rhinology & Allergy (98)
+- **October 2025**: Laryngology & Voice (211), Otology & Neurotology (127), Rhinology & Allergy (126), General ENT/Other (101)
+- **November 2025**: Laryngology & Voice (206), General ENT/Other (157), Otology & Neurotology (129), Rhinology & Allergy (126)

--- a/data/journal_club.json
+++ b/data/journal_club.json
@@ -11,7 +11,9 @@
       "pmid": "41319160",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41319160/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -27,7 +29,10 @@
       "pmid": "41318223",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41318223/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -43,7 +48,9 @@
       "pmid": "41307355",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41307355/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -59,7 +66,10 @@
       "pmid": "41317131",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41317131/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -75,7 +85,10 @@
       "pmid": "41311202",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41311202/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -91,7 +104,11 @@
       "pmid": "41316714",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41316714/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -107,7 +124,9 @@
       "pmid": "41316682",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41316682/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -123,7 +142,10 @@
       "pmid": "41316736",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41316736/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -139,7 +161,10 @@
       "pmid": "41313596",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41313596/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -155,7 +180,12 @@
       "pmid": "41311275",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41311275/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -171,7 +201,12 @@
       "pmid": "41311266",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41311266/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -187,7 +222,10 @@
       "pmid": "41316713",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41316713/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -203,7 +241,11 @@
       "pmid": "41307177",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41307177/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -219,7 +261,10 @@
       "pmid": "41311113",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41311113/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -235,7 +280,12 @@
       "pmid": "41311098",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41311098/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -251,7 +301,11 @@
       "pmid": "41307209",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41307209/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -267,7 +321,11 @@
       "pmid": "41307155",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41307155/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -283,7 +341,10 @@
       "pmid": "41311123",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41311123/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -299,7 +360,10 @@
       "pmid": "41307481",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41307481/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -315,7 +379,12 @@
       "pmid": "41305853",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41305853/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -331,7 +400,10 @@
       "pmid": "41294279",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41294279/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -347,7 +419,9 @@
       "pmid": "41296366",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296366/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -363,7 +437,10 @@
       "pmid": "41296362",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296362/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -379,7 +456,9 @@
       "pmid": "41296368",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296368/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -395,7 +474,9 @@
       "pmid": "41296332",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296332/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -411,7 +492,9 @@
       "pmid": "41296348",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296348/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -427,7 +510,9 @@
       "pmid": "41296335",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296335/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -443,7 +528,10 @@
       "pmid": "41299869",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41299869/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -459,7 +547,13 @@
       "pmid": "41305852",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41305852/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Salivary & Oral Cavity",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -475,7 +569,10 @@
       "pmid": "41299874",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41299874/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -491,7 +588,9 @@
       "pmid": "41296327",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296327/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -507,7 +606,9 @@
       "pmid": "41296333",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296333/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -523,7 +624,9 @@
       "pmid": "41296353",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296353/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -539,7 +642,10 @@
       "pmid": "41293894",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41293894/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -555,7 +661,9 @@
       "pmid": "41294016",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41294016/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -571,7 +679,10 @@
       "pmid": "41293890",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41293890/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -587,7 +698,9 @@
       "pmid": "41296350",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41296350/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -603,7 +716,11 @@
       "pmid": "41293848",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41293848/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -619,7 +736,9 @@
       "pmid": "41123913",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123913/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -635,7 +754,10 @@
       "pmid": "41114994",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41114994/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -651,7 +773,9 @@
       "pmid": "41288571",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41288571/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -667,7 +791,9 @@
       "pmid": "41115000",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41115000/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -683,7 +809,9 @@
       "pmid": "41288558",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41288558/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -699,7 +827,10 @@
       "pmid": "41114991",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41114991/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -715,7 +846,11 @@
       "pmid": "41288142",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41288142/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -731,7 +866,9 @@
       "pmid": "41066101",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41066101/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -747,7 +884,9 @@
       "pmid": "41134580",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134580/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -763,7 +902,9 @@
       "pmid": "41134554",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134554/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -779,7 +920,9 @@
       "pmid": "41288275",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41288275/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -795,7 +938,9 @@
       "pmid": "41060623",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41060623/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -811,7 +956,10 @@
       "pmid": "41123939",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123939/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -827,7 +975,9 @@
       "pmid": "41134583",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134583/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -843,7 +993,9 @@
       "pmid": "41134568",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134568/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -859,7 +1011,9 @@
       "pmid": "41114967",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41114967/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -875,7 +1029,10 @@
       "pmid": "41289294",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41289294/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -891,7 +1048,9 @@
       "pmid": "41114965",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41114965/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -907,7 +1066,9 @@
       "pmid": "41114969",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41114969/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -923,7 +1084,10 @@
       "pmid": "41114973",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41114973/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -939,7 +1103,9 @@
       "pmid": "41051749",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051749/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -955,7 +1121,9 @@
       "pmid": "41123932",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123932/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -971,7 +1139,9 @@
       "pmid": "41114968",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41114968/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -987,7 +1157,10 @@
       "pmid": "41065638",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41065638/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1003,7 +1176,9 @@
       "pmid": "41288614",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41288614/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1019,7 +1194,9 @@
       "pmid": "41134564",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134564/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1035,7 +1212,9 @@
       "pmid": "41123919",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123919/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1051,7 +1230,9 @@
       "pmid": "41165688",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165688/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1067,7 +1248,9 @@
       "pmid": "41134592",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134592/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1083,7 +1266,9 @@
       "pmid": "41032309",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032309/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1099,7 +1284,9 @@
       "pmid": "40991250",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40991250/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1115,7 +1302,9 @@
       "pmid": "41134591",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134591/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1131,7 +1320,9 @@
       "pmid": "41051746",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051746/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1147,7 +1338,9 @@
       "pmid": "41065642",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41065642/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1163,7 +1356,9 @@
       "pmid": "41091502",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091502/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1179,7 +1374,9 @@
       "pmid": "41115001",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41115001/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1195,7 +1392,9 @@
       "pmid": "41134567",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134567/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1211,7 +1410,9 @@
       "pmid": "41100116",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100116/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1227,7 +1428,11 @@
       "pmid": "41277306",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41277306/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1243,7 +1448,9 @@
       "pmid": "41284263",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41284263/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1259,7 +1466,9 @@
       "pmid": "41284289",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41284289/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1275,7 +1484,9 @@
       "pmid": "41284277",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41284277/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1291,7 +1502,9 @@
       "pmid": "41284290",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41284290/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1307,7 +1520,9 @@
       "pmid": "41284273",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41284273/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1323,7 +1538,9 @@
       "pmid": "41284284",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41284284/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1339,7 +1556,11 @@
       "pmid": "41284038",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41284038/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1355,7 +1576,9 @@
       "pmid": "41283927",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41283927/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1371,7 +1594,10 @@
       "pmid": "41283226",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41283226/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1387,7 +1613,9 @@
       "pmid": "41277387",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41277387/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1403,7 +1631,9 @@
       "pmid": "41277314",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41277314/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1419,7 +1649,10 @@
       "pmid": "41276418",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41276418/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1435,7 +1668,11 @@
       "pmid": "41273225",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41273225/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1451,7 +1688,9 @@
       "pmid": "41269688",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269688/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1467,7 +1706,10 @@
       "pmid": "41267563",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41267563/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1483,7 +1725,9 @@
       "pmid": "41269705",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269705/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1499,7 +1743,9 @@
       "pmid": "41269030",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269030/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1515,7 +1761,9 @@
       "pmid": "41269681",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269681/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1531,7 +1779,9 @@
       "pmid": "41269682",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269682/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1547,7 +1797,9 @@
       "pmid": "41269697",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269697/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1563,7 +1815,9 @@
       "pmid": "41269680",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269680/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1579,7 +1833,9 @@
       "pmid": "41269686",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269686/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1595,7 +1851,9 @@
       "pmid": "41269679",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269679/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1611,7 +1869,11 @@
       "pmid": "41269034",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41269034/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Infectious Disease",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1627,7 +1889,11 @@
       "pmid": "41264302",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264302/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1643,7 +1909,9 @@
       "pmid": "41264312",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264312/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1659,7 +1927,9 @@
       "pmid": "41264283",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264283/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1675,7 +1945,9 @@
       "pmid": "41264303",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264303/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1691,7 +1963,11 @@
       "pmid": "41264310",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264310/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1707,7 +1983,9 @@
       "pmid": "41264298",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264298/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1723,7 +2001,9 @@
       "pmid": "41264315",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264315/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1739,7 +2019,12 @@
       "pmid": "41264293",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264293/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1755,7 +2040,10 @@
       "pmid": "41264277",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264277/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1771,7 +2059,9 @@
       "pmid": "41264264",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264264/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1787,7 +2077,10 @@
       "pmid": "41263474",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41263474/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1803,7 +2096,9 @@
       "pmid": "41264305",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264305/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1819,7 +2114,10 @@
       "pmid": "41264279",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41264279/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1835,7 +2133,12 @@
       "pmid": "41259331",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259331/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Infectious Disease",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1851,7 +2154,10 @@
       "pmid": "41259039",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259039/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1867,7 +2173,10 @@
       "pmid": "41259044",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259044/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1883,7 +2192,11 @@
       "pmid": "41257416",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41257416/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1899,7 +2212,10 @@
       "pmid": "41257399",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41257399/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1915,7 +2231,9 @@
       "pmid": "41259042",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259042/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1931,7 +2249,10 @@
       "pmid": "41259054",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259054/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1947,7 +2268,9 @@
       "pmid": "41259052",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259052/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1963,7 +2286,9 @@
       "pmid": "41259009",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259009/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1979,7 +2304,9 @@
       "pmid": "41259198",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259198/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -1995,7 +2322,9 @@
       "pmid": "41259034",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259034/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2011,7 +2340,9 @@
       "pmid": "41259927",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41259927/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2027,7 +2358,9 @@
       "pmid": "41251292",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41251292/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2043,7 +2376,10 @@
       "pmid": "41247318",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41247318/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2059,7 +2395,9 @@
       "pmid": "41247757",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41247757/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2075,7 +2413,9 @@
       "pmid": "41247717",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41247717/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2091,7 +2431,9 @@
       "pmid": "41243874",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41243874/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2107,7 +2449,9 @@
       "pmid": "41247727",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41247727/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2123,7 +2467,10 @@
       "pmid": "41252911",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41252911/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2139,7 +2486,10 @@
       "pmid": "41247333",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41247333/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2155,7 +2505,9 @@
       "pmid": "41247746",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41247746/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2171,7 +2523,9 @@
       "pmid": "41247719",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41247719/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2187,7 +2541,10 @@
       "pmid": "41247343",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41247343/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2203,7 +2560,9 @@
       "pmid": "41236730",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41236730/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2219,7 +2578,9 @@
       "pmid": "41236775",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41236775/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2235,7 +2596,11 @@
       "pmid": "41239568",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41239568/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2251,7 +2616,9 @@
       "pmid": "41236760",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41236760/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2267,7 +2634,9 @@
       "pmid": "41239801",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41239801/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2283,7 +2652,9 @@
       "pmid": "41236749",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41236749/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2299,7 +2670,9 @@
       "pmid": "41236731",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41236731/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2315,7 +2688,9 @@
       "pmid": "41236773",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41236773/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2331,7 +2706,10 @@
       "pmid": "41235568",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41235568/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2347,7 +2725,10 @@
       "pmid": "41235417",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41235417/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2363,7 +2744,10 @@
       "pmid": "41235453",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41235453/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2379,7 +2763,9 @@
       "pmid": "41236735",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41236735/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2395,7 +2781,11 @@
       "pmid": "41240671",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41240671/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2411,7 +2801,11 @@
       "pmid": "41240669",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41240669/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2427,7 +2821,11 @@
       "pmid": "41240670",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41240670/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2443,7 +2841,9 @@
       "pmid": "41236726",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41236726/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2459,7 +2859,9 @@
       "pmid": "41231491",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231491/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2475,7 +2877,9 @@
       "pmid": "41230604",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41230604/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2491,7 +2895,9 @@
       "pmid": "41231496",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231496/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2507,7 +2913,9 @@
       "pmid": "41231479",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231479/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2523,7 +2931,10 @@
       "pmid": "41231500",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231500/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2539,7 +2950,10 @@
       "pmid": "41231509",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231509/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2555,7 +2969,11 @@
       "pmid": "41231503",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231503/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2571,7 +2989,9 @@
       "pmid": "41231448",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231448/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2587,7 +3007,10 @@
       "pmid": "41231490",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231490/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2603,7 +3026,9 @@
       "pmid": "41231449",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231449/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2619,7 +3044,9 @@
       "pmid": "41231482",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231482/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2635,7 +3062,10 @@
       "pmid": "41230605",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41230605/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2651,7 +3081,10 @@
       "pmid": "41230659",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41230659/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2667,7 +3100,11 @@
       "pmid": "41231483",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231483/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2683,7 +3120,11 @@
       "pmid": "41231484",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231484/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2699,7 +3140,11 @@
       "pmid": "41231478",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231478/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2715,7 +3160,9 @@
       "pmid": "41231668",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231668/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2731,7 +3178,9 @@
       "pmid": "41231453",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231453/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2747,7 +3196,10 @@
       "pmid": "41230621",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41230621/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2763,7 +3215,10 @@
       "pmid": "41231495",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231495/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2779,7 +3234,9 @@
       "pmid": "41230706",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41230706/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2795,7 +3252,9 @@
       "pmid": "41231489",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231489/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2811,7 +3270,9 @@
       "pmid": "41231663",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231663/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2827,7 +3288,9 @@
       "pmid": "41231515",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231515/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2843,7 +3306,9 @@
       "pmid": "41231505",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231505/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2859,7 +3324,9 @@
       "pmid": "41222928",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41222928/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2875,7 +3342,10 @@
       "pmid": "41221790",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41221790/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2891,7 +3361,11 @@
       "pmid": "41233267",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41233267/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2907,7 +3381,9 @@
       "pmid": "41222951",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41222951/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2923,7 +3399,10 @@
       "pmid": "41222308",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41222308/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2939,7 +3418,9 @@
       "pmid": "41222924",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41222924/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2955,7 +3436,9 @@
       "pmid": "41222954",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41222954/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2971,7 +3454,9 @@
       "pmid": "41222921",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41222921/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -2987,7 +3472,9 @@
       "pmid": "41222941",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41222941/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3003,7 +3490,9 @@
       "pmid": "41026480",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41026480/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3019,7 +3508,9 @@
       "pmid": "40853565",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40853565/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3035,7 +3526,9 @@
       "pmid": "41071544",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41071544/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3051,7 +3544,9 @@
       "pmid": "41066102",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41066102/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3067,7 +3562,9 @@
       "pmid": "41100125",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100125/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3083,7 +3580,9 @@
       "pmid": "41066088",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41066088/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3099,7 +3598,9 @@
       "pmid": "41060633",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41060633/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3115,7 +3616,9 @@
       "pmid": "41071565",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41071565/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3131,7 +3634,9 @@
       "pmid": "41217449",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41217449/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3147,7 +3652,9 @@
       "pmid": "41071570",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41071570/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3163,7 +3670,9 @@
       "pmid": "41100095",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100095/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3179,7 +3688,9 @@
       "pmid": "41021256",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41021256/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3195,7 +3706,9 @@
       "pmid": "41051762",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051762/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3211,7 +3724,9 @@
       "pmid": "41071558",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41071558/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3227,7 +3742,10 @@
       "pmid": "41037291",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037291/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3243,7 +3761,9 @@
       "pmid": "41071577",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41071577/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3259,7 +3779,9 @@
       "pmid": "41071576",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41071576/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3275,7 +3797,9 @@
       "pmid": "41051755",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051755/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3291,7 +3815,9 @@
       "pmid": "41082366",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41082366/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3307,7 +3833,9 @@
       "pmid": "41051742",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051742/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3323,7 +3851,9 @@
       "pmid": "41021246",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41021246/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3339,7 +3869,9 @@
       "pmid": "41051784",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051784/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3355,7 +3887,9 @@
       "pmid": "41032295",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032295/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3371,7 +3905,9 @@
       "pmid": "41026475",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41026475/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3387,7 +3923,10 @@
       "pmid": "41071545",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41071545/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3403,7 +3942,9 @@
       "pmid": "40886310",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40886310/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3419,7 +3960,9 @@
       "pmid": "41032307",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032307/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3435,7 +3978,10 @@
       "pmid": "41037263",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037263/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3451,7 +3997,9 @@
       "pmid": "40982246",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40982246/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3467,7 +4015,9 @@
       "pmid": "40996740",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996740/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3483,7 +4033,9 @@
       "pmid": "40982240",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40982240/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3499,7 +4051,9 @@
       "pmid": "40920508",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40920508/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3515,7 +4069,9 @@
       "pmid": "41071574",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41071574/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3531,7 +4087,9 @@
       "pmid": "41060624",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41060624/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3547,7 +4105,9 @@
       "pmid": "41051744",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051744/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3563,7 +4123,9 @@
       "pmid": "41212720",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41212720/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3579,7 +4141,9 @@
       "pmid": "41212542",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41212542/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3595,7 +4159,10 @@
       "pmid": "41212550",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41212550/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3611,7 +4178,9 @@
       "pmid": "41212541",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41212541/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3627,7 +4196,9 @@
       "pmid": "41212548",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41212548/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3643,7 +4214,9 @@
       "pmid": "41212715",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41212715/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3659,7 +4232,10 @@
       "pmid": "41208513",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41208513/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3675,7 +4251,9 @@
       "pmid": "41208533",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41208533/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3691,7 +4269,9 @@
       "pmid": "41212566",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41212566/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3707,7 +4287,9 @@
       "pmid": "41206799",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206799/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3723,7 +4305,9 @@
       "pmid": "41206971",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206971/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3739,7 +4323,9 @@
       "pmid": "41206972",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206972/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3755,7 +4341,9 @@
       "pmid": "41206974",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206974/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3771,7 +4359,9 @@
       "pmid": "41206900",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206900/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3787,7 +4377,10 @@
       "pmid": "41206967",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206967/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3803,7 +4396,9 @@
       "pmid": "41206801",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206801/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3819,7 +4414,9 @@
       "pmid": "41206802",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206802/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3835,7 +4432,9 @@
       "pmid": "41206969",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206969/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3851,7 +4450,9 @@
       "pmid": "41206973",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41206973/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3867,7 +4468,9 @@
       "pmid": "41205146",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41205146/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3883,7 +4486,9 @@
       "pmid": "41205228",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41205228/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3899,7 +4504,10 @@
       "pmid": "41205148",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41205148/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3915,7 +4523,9 @@
       "pmid": "41205227",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41205227/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3931,7 +4541,9 @@
       "pmid": "41201828",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41201828/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3947,7 +4559,9 @@
       "pmid": "41201829",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41201829/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3963,7 +4577,9 @@
       "pmid": "41202183",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41202183/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3979,7 +4595,9 @@
       "pmid": "41202182",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41202182/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -3995,7 +4613,10 @@
       "pmid": "41201895",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41201895/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4011,7 +4632,9 @@
       "pmid": "41203233",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41203233/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4027,7 +4650,9 @@
       "pmid": "41201830",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41201830/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4043,7 +4668,9 @@
       "pmid": "41202034",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41202034/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4059,7 +4686,9 @@
       "pmid": "41203232",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41203232/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4075,7 +4704,9 @@
       "pmid": "41201902",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41201902/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4091,7 +4722,9 @@
       "pmid": "41202026",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41202026/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4107,7 +4740,9 @@
       "pmid": "41201797",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41201797/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4123,7 +4758,9 @@
       "pmid": "41201795",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41201795/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4139,7 +4776,9 @@
       "pmid": "41201798",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41201798/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4155,7 +4794,9 @@
       "pmid": "41201832",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41201832/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4171,7 +4812,10 @@
       "pmid": "41200864",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41200864/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4187,7 +4831,9 @@
       "pmid": "41196591",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196591/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4203,7 +4849,9 @@
       "pmid": "41196628",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196628/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4219,7 +4867,9 @@
       "pmid": "41196609",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196609/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4235,7 +4885,10 @@
       "pmid": "41196582",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196582/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4251,7 +4904,9 @@
       "pmid": "41196627",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196627/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4267,7 +4922,9 @@
       "pmid": "41196626",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196626/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4283,7 +4940,10 @@
       "pmid": "41195694",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41195694/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4299,7 +4959,9 @@
       "pmid": "41196589",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196589/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4315,7 +4977,10 @@
       "pmid": "41196578",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196578/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4331,7 +4996,9 @@
       "pmid": "41196584",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196584/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4347,7 +5014,9 @@
       "pmid": "41196581",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196581/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4363,7 +5032,9 @@
       "pmid": "41196617",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196617/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4379,7 +5050,9 @@
       "pmid": "41196608",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196608/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4395,7 +5068,10 @@
       "pmid": "41196585",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196585/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4411,7 +5087,10 @@
       "pmid": "41196615",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196615/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4427,7 +5106,11 @@
       "pmid": "41196606",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196606/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4443,7 +5126,9 @@
       "pmid": "41196579",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41196579/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4459,7 +5144,11 @@
       "pmid": "41190732",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41190732/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4475,7 +5164,12 @@
       "pmid": "41190698",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41190698/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4491,7 +5185,9 @@
       "pmid": "41191367",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41191367/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4507,7 +5203,9 @@
       "pmid": "41191364",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41191364/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4523,7 +5221,10 @@
       "pmid": "41190729",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41190729/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4539,7 +5240,9 @@
       "pmid": "41191365",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41191365/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4555,7 +5258,10 @@
       "pmid": "41190691",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41190691/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4571,7 +5277,9 @@
       "pmid": "41191338",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41191338/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4587,7 +5295,9 @@
       "pmid": "41191366",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41191366/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4603,7 +5313,9 @@
       "pmid": "41191403",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41191403/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4619,7 +5331,10 @@
       "pmid": "41191375",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41191375/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4635,7 +5350,10 @@
       "pmid": "41190699",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41190699/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4651,7 +5369,9 @@
       "pmid": "41186274",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41186274/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4667,7 +5387,9 @@
       "pmid": "41186943",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41186943/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4683,7 +5405,9 @@
       "pmid": "40920391",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40920391/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4699,7 +5423,9 @@
       "pmid": "40982270",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40982270/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4715,7 +5441,9 @@
       "pmid": "41042518",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41042518/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4731,7 +5459,9 @@
       "pmid": "41042535",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41042535/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4747,7 +5477,10 @@
       "pmid": "41186972",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41186972/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4763,7 +5496,9 @@
       "pmid": "40996742",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996742/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4779,7 +5514,9 @@
       "pmid": "40982242",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40982242/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4795,7 +5532,9 @@
       "pmid": "40875583",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875583/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4811,7 +5550,9 @@
       "pmid": "41042533",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41042533/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4827,7 +5568,9 @@
       "pmid": "40914902",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40914902/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4843,7 +5586,9 @@
       "pmid": "41186256",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41186256/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4859,7 +5604,9 @@
       "pmid": "41021241",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41021241/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4875,7 +5622,9 @@
       "pmid": "41037278",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037278/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4891,7 +5640,9 @@
       "pmid": "41042505",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41042505/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4907,7 +5658,9 @@
       "pmid": "41186242",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41186242/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4923,7 +5676,9 @@
       "pmid": "41186243",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41186243/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4939,7 +5694,9 @@
       "pmid": "40996728",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996728/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4955,7 +5712,9 @@
       "pmid": "40996725",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996725/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4971,7 +5730,9 @@
       "pmid": "41042521",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41042521/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -4987,7 +5748,9 @@
       "pmid": "40996738",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996738/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5003,7 +5766,9 @@
       "pmid": "40991297",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40991297/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5019,7 +5784,9 @@
       "pmid": "41186942",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41186942/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5035,7 +5802,9 @@
       "pmid": "40996726",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996726/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5051,7 +5820,9 @@
       "pmid": "40932706",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932706/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5067,7 +5838,9 @@
       "pmid": "40982293",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40982293/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5083,7 +5856,9 @@
       "pmid": "41042537",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41042537/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5099,7 +5874,9 @@
       "pmid": "41066090",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41066090/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5115,7 +5892,9 @@
       "pmid": "41042530",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41042530/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5131,7 +5910,9 @@
       "pmid": "40991244",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40991244/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5147,7 +5928,9 @@
       "pmid": "40996741",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996741/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5163,7 +5946,10 @@
       "pmid": "40991296",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40991296/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5179,7 +5965,11 @@
       "pmid": "41193299",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41193299/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5195,7 +5985,9 @@
       "pmid": "41042520",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41042520/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5211,7 +6003,10 @@
       "pmid": "41193300",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41193300/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5227,7 +6022,9 @@
       "pmid": "40996748",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996748/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5243,7 +6040,9 @@
       "pmid": "41186632",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41186632/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5259,7 +6058,9 @@
       "pmid": "40932726",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932726/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5275,7 +6076,9 @@
       "pmid": "40991245",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40991245/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5291,7 +6094,9 @@
       "pmid": "41021234",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41021234/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5307,7 +6112,9 @@
       "pmid": "41186263",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41186263/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5323,7 +6130,9 @@
       "pmid": "41021328",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41021328/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5339,7 +6148,9 @@
       "pmid": "40996747",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996747/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5355,7 +6166,9 @@
       "pmid": "41178691",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41178691/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5371,7 +6184,11 @@
       "pmid": "41178694",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41178694/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5387,7 +6204,11 @@
       "pmid": "41178695",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41178695/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5403,7 +6224,9 @@
       "pmid": "41182719",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41182719/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5419,7 +6242,9 @@
       "pmid": "41182882",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41182882/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5435,7 +6260,10 @@
       "pmid": "41182880",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41182880/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5451,7 +6279,9 @@
       "pmid": "41182738",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41182738/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5467,7 +6297,11 @@
       "pmid": "41183427",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41183427/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5483,7 +6317,12 @@
       "pmid": "41183426",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41183426/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5499,7 +6338,11 @@
       "pmid": "40246597",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40246597/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5515,7 +6358,9 @@
       "pmid": "41091522",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091522/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5531,7 +6376,10 @@
       "pmid": "40539731",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40539731/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5547,7 +6395,11 @@
       "pmid": "40497646",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40497646/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5563,7 +6415,10 @@
       "pmid": "40485637",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40485637/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5579,7 +6434,13 @@
       "pmid": "40346891",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40346891/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5595,7 +6456,10 @@
       "pmid": "40411299",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40411299/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5611,7 +6475,10 @@
       "pmid": "40673644",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40673644/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5627,7 +6494,10 @@
       "pmid": "40511882",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40511882/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5643,7 +6513,9 @@
       "pmid": "40518939",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40518939/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5659,7 +6531,9 @@
       "pmid": "40600899",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40600899/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5675,7 +6549,10 @@
       "pmid": "40506320",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40506320/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5691,7 +6568,10 @@
       "pmid": "40515518",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40515518/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5707,7 +6587,10 @@
       "pmid": "40387261",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40387261/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5723,7 +6606,10 @@
       "pmid": "40348727",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40348727/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5739,7 +6625,9 @@
       "pmid": "40607723",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40607723/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5755,7 +6643,12 @@
       "pmid": "40546102",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40546102/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5771,7 +6664,11 @@
       "pmid": "40820948",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40820948/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5787,7 +6684,9 @@
       "pmid": "40574724",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40574724/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5803,7 +6702,11 @@
       "pmid": "40407268",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40407268/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5819,7 +6722,11 @@
       "pmid": "40492391",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40492391/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5835,7 +6742,9 @@
       "pmid": "40938508",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40938508/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5851,7 +6760,10 @@
       "pmid": "40539727",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40539727/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5867,7 +6779,10 @@
       "pmid": "40521848",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40521848/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5883,7 +6798,9 @@
       "pmid": "40590437",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40590437/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5899,7 +6816,9 @@
       "pmid": "40879285",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40879285/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5915,7 +6834,9 @@
       "pmid": "40873415",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40873415/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5931,7 +6852,10 @@
       "pmid": "40497673",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40497673/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5947,7 +6871,10 @@
       "pmid": "40920340",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40920340/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5963,7 +6890,10 @@
       "pmid": "40911435",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911435/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5979,7 +6909,11 @@
       "pmid": "40371981",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40371981/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -5995,7 +6929,11 @@
       "pmid": "40760843",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40760843/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6011,7 +6949,11 @@
       "pmid": "40682374",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40682374/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6027,7 +6969,10 @@
       "pmid": "40468861",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40468861/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6043,7 +6988,10 @@
       "pmid": "40530792",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40530792/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6059,7 +7007,12 @@
       "pmid": "40542650",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40542650/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6075,7 +7028,9 @@
       "pmid": "40833283",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40833283/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6091,7 +7046,10 @@
       "pmid": "40546131",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40546131/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6107,7 +7065,11 @@
       "pmid": "40757398",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40757398/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6123,7 +7085,11 @@
       "pmid": "40544031",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40544031/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6139,7 +7105,11 @@
       "pmid": "40421816",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40421816/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6155,7 +7125,10 @@
       "pmid": "40734421",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40734421/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6171,7 +7144,10 @@
       "pmid": "40481757",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40481757/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6187,7 +7163,11 @@
       "pmid": "40246598",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40246598/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6203,7 +7183,10 @@
       "pmid": "40825100",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40825100/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6219,7 +7202,9 @@
       "pmid": "40323110",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40323110/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6235,7 +7220,11 @@
       "pmid": "40407196",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40407196/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6251,7 +7240,10 @@
       "pmid": "40667670",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40667670/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6267,7 +7259,10 @@
       "pmid": "40631784",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40631784/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6283,7 +7278,11 @@
       "pmid": "40613475",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40613475/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6299,7 +7298,11 @@
       "pmid": "40514299",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40514299/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6315,7 +7318,10 @@
       "pmid": "40600933",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40600933/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6331,7 +7337,11 @@
       "pmid": "40662411",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40662411/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6347,7 +7357,11 @@
       "pmid": "40365852",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40365852/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Infectious Disease",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6363,7 +7377,10 @@
       "pmid": "40387278",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40387278/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6379,7 +7396,10 @@
       "pmid": "40613471",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40613471/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6395,7 +7415,10 @@
       "pmid": "40607693",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40607693/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6411,7 +7434,11 @@
       "pmid": "40421828",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40421828/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6427,7 +7454,11 @@
       "pmid": "40474614",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40474614/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6443,7 +7474,10 @@
       "pmid": "40685625",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40685625/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6459,7 +7493,10 @@
       "pmid": "40673643",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40673643/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6475,7 +7512,12 @@
       "pmid": "40481759",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40481759/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Salivary & Oral Cavity",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6491,7 +7533,9 @@
       "pmid": "40685623",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40685623/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6507,7 +7551,10 @@
       "pmid": "40444498",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40444498/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6523,7 +7570,11 @@
       "pmid": "40781903",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40781903/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6539,7 +7590,9 @@
       "pmid": "40948322",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40948322/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6555,7 +7608,10 @@
       "pmid": "41045293",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41045293/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6571,7 +7627,11 @@
       "pmid": "40497641",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40497641/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6587,7 +7647,10 @@
       "pmid": "40825091",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40825091/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6603,7 +7666,10 @@
       "pmid": "41033916",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41033916/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6619,7 +7685,12 @@
       "pmid": "40481758",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40481758/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6635,7 +7706,9 @@
       "pmid": "40988590",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40988590/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6651,7 +7724,10 @@
       "pmid": "40879571",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40879571/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6667,7 +7743,12 @@
       "pmid": "40539375",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40539375/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6683,7 +7764,13 @@
       "pmid": "40746260",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40746260/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6699,7 +7786,9 @@
       "pmid": "40900615",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40900615/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6715,7 +7804,9 @@
       "pmid": "40886293",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40886293/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6731,7 +7822,10 @@
       "pmid": "40613547",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40613547/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6747,7 +7841,9 @@
       "pmid": "40911423",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911423/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6763,7 +7859,10 @@
       "pmid": "40631799",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40631799/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6779,7 +7878,10 @@
       "pmid": "40454779",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40454779/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6795,7 +7897,10 @@
       "pmid": "40530756",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40530756/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6811,7 +7916,10 @@
       "pmid": "41025535",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41025535/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6827,7 +7935,9 @@
       "pmid": "40616414",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40616414/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6843,7 +7953,10 @@
       "pmid": "40280805",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40280805/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6859,7 +7972,10 @@
       "pmid": "40760831",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40760831/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6875,7 +7991,10 @@
       "pmid": "40820344",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40820344/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6891,7 +8010,11 @@
       "pmid": "40673661",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40673661/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6907,7 +8030,13 @@
       "pmid": "40459289",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40459289/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6923,7 +8052,11 @@
       "pmid": "40842217",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40842217/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6939,7 +8072,10 @@
       "pmid": "39984346",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39984346/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6955,7 +8091,10 @@
       "pmid": "40855774",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40855774/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6971,7 +8110,9 @@
       "pmid": "41091540",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091540/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -6987,7 +8128,12 @@
       "pmid": "40613458",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40613458/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7003,7 +8149,11 @@
       "pmid": "40280807",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40280807/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7019,7 +8169,10 @@
       "pmid": "40481760",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40481760/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7035,7 +8188,11 @@
       "pmid": "40488220",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40488220/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7051,7 +8208,11 @@
       "pmid": "40600641",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40600641/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7067,7 +8228,10 @@
       "pmid": "40891773",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40891773/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7083,7 +8247,10 @@
       "pmid": "40417805",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40417805/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7099,7 +8266,10 @@
       "pmid": "41046239",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41046239/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7115,7 +8285,9 @@
       "pmid": "40808535",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40808535/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7131,7 +8303,10 @@
       "pmid": "40497648",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40497648/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7147,7 +8322,10 @@
       "pmid": "40444528",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40444528/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7163,7 +8341,12 @@
       "pmid": "39689989",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39689989/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7179,7 +8362,10 @@
       "pmid": "40747757",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40747757/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7195,7 +8381,9 @@
       "pmid": "40600908",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40600908/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7211,7 +8399,9 @@
       "pmid": "40631777",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40631777/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7227,7 +8417,11 @@
       "pmid": "41038737",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41038737/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7243,7 +8437,10 @@
       "pmid": "41048194",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41048194/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7259,7 +8456,11 @@
       "pmid": "40497654",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40497654/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7275,7 +8476,11 @@
       "pmid": "40497597",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40497597/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7291,7 +8496,10 @@
       "pmid": "40855776",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40855776/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7307,7 +8515,11 @@
       "pmid": "40444420",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40444420/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7323,7 +8535,13 @@
       "pmid": "40365836",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40365836/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Salivary & Oral Cavity",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7339,7 +8557,9 @@
       "pmid": "40873416",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40873416/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7355,7 +8575,9 @@
       "pmid": "40906498",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906498/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7371,7 +8593,11 @@
       "pmid": "40781917",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40781917/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7387,7 +8613,10 @@
       "pmid": "40679157",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40679157/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7403,7 +8632,10 @@
       "pmid": "40600254",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40600254/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7419,7 +8651,11 @@
       "pmid": "40439047",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40439047/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7435,7 +8671,10 @@
       "pmid": "40344223",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40344223/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7451,7 +8690,9 @@
       "pmid": "40607715",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40607715/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7467,7 +8708,9 @@
       "pmid": "41025555",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41025555/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7483,7 +8726,13 @@
       "pmid": "40268576",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40268576/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7499,7 +8748,12 @@
       "pmid": "40382283",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40382283/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7515,7 +8769,11 @@
       "pmid": "40626789",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40626789/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7531,7 +8789,11 @@
       "pmid": "41037306",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037306/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7547,7 +8809,10 @@
       "pmid": "40932708",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932708/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7563,7 +8828,10 @@
       "pmid": "40932732",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932732/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7579,7 +8847,10 @@
       "pmid": "40996743",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996743/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7595,7 +8866,9 @@
       "pmid": "40965903",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965903/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7611,7 +8884,11 @@
       "pmid": "40932704",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932704/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7627,7 +8904,10 @@
       "pmid": "40996729",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996729/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7643,7 +8923,9 @@
       "pmid": "40965859",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965859/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7659,7 +8941,11 @@
       "pmid": "41037309",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037309/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7675,7 +8961,11 @@
       "pmid": "41037305",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037305/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7691,7 +8981,9 @@
       "pmid": "41037290",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037290/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7707,7 +8999,10 @@
       "pmid": "40996749",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996749/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7723,7 +9018,9 @@
       "pmid": "40965912",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965912/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7739,7 +9036,12 @@
       "pmid": "41066095",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41066095/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7755,7 +9057,9 @@
       "pmid": "41231499",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41231499/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7771,7 +9075,10 @@
       "pmid": "41066100",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41066100/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7787,7 +9094,10 @@
       "pmid": "41037280",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037280/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7803,7 +9113,12 @@
       "pmid": "41176962",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41176962/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7819,7 +9134,9 @@
       "pmid": "40965895",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965895/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7835,7 +9152,10 @@
       "pmid": "40996724",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996724/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7851,7 +9171,11 @@
       "pmid": "41037286",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037286/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7867,7 +9191,9 @@
       "pmid": "40965872",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965872/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7883,7 +9209,10 @@
       "pmid": "40932730",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932730/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7899,7 +9228,13 @@
       "pmid": "40965870",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965870/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Salivary & Oral Cavity",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7915,7 +9250,9 @@
       "pmid": "40965919",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965919/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7931,7 +9268,9 @@
       "pmid": "41171265",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41171265/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7947,7 +9286,9 @@
       "pmid": "41170812",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41170812/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7963,7 +9304,9 @@
       "pmid": "41171291",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41171291/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7979,7 +9322,10 @@
       "pmid": "41171255",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41171255/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -7995,7 +9341,9 @@
       "pmid": "41171285",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41171285/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8011,7 +9359,9 @@
       "pmid": "41171266",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41171266/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8027,7 +9377,9 @@
       "pmid": "41171293",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41171293/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8043,7 +9395,10 @@
       "pmid": "41171089",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41171089/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8059,7 +9414,9 @@
       "pmid": "41171258",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41171258/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8075,7 +9432,9 @@
       "pmid": "41171284",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41171284/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8091,7 +9450,11 @@
       "pmid": "41165077",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165077/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8107,7 +9470,9 @@
       "pmid": "41165718",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165718/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8123,7 +9488,9 @@
       "pmid": "41165681",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165681/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8139,7 +9506,10 @@
       "pmid": "41165699",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165699/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8155,7 +9525,9 @@
       "pmid": "41165684",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165684/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8171,7 +9543,9 @@
       "pmid": "41165716",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165716/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8187,7 +9561,9 @@
       "pmid": "41165682",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165682/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8203,7 +9579,10 @@
       "pmid": "41165060",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165060/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8219,7 +9598,9 @@
       "pmid": "41165717",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165717/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8235,7 +9616,9 @@
       "pmid": "41165680",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165680/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8251,7 +9634,11 @@
       "pmid": "41165679",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165679/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8267,7 +9654,11 @@
       "pmid": "41165715",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165715/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8283,7 +9674,10 @@
       "pmid": "41165676",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165676/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8299,7 +9693,9 @@
       "pmid": "41165702",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165702/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8315,7 +9711,11 @@
       "pmid": "41164995",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41164995/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8331,7 +9731,9 @@
       "pmid": "41165069",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165069/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8347,7 +9749,10 @@
       "pmid": "41165068",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165068/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8363,7 +9768,10 @@
       "pmid": "41165685",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165685/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8379,7 +9787,10 @@
       "pmid": "41165672",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41165672/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8395,7 +9806,11 @@
       "pmid": "41159677",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159677/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8411,7 +9826,9 @@
       "pmid": "41159812",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159812/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8427,7 +9844,9 @@
       "pmid": "41160035",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41160035/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8443,7 +9862,9 @@
       "pmid": "41160415",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41160415/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8459,7 +9880,10 @@
       "pmid": "41159824",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159824/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8475,7 +9899,9 @@
       "pmid": "41159826",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159826/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8491,7 +9917,9 @@
       "pmid": "41159835",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159835/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8507,7 +9935,9 @@
       "pmid": "41159661",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159661/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8523,7 +9953,10 @@
       "pmid": "41159249",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159249/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8539,7 +9972,9 @@
       "pmid": "41160021",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41160021/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8555,7 +9990,9 @@
       "pmid": "41160009",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41160009/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8571,7 +10008,10 @@
       "pmid": "41159727",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159727/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8587,7 +10027,9 @@
       "pmid": "41159825",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159825/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8603,7 +10045,9 @@
       "pmid": "41159832",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159832/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8619,7 +10063,10 @@
       "pmid": "41159714",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159714/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8635,7 +10082,10 @@
       "pmid": "41158102",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41158102/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8651,7 +10101,10 @@
       "pmid": "41158109",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41158109/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8667,7 +10120,9 @@
       "pmid": "41159833",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41159833/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8683,7 +10138,9 @@
       "pmid": "41160046",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41160046/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8699,7 +10156,9 @@
       "pmid": "40720119",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40720119/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8715,7 +10174,9 @@
       "pmid": "40884494",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40884494/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8731,7 +10192,9 @@
       "pmid": "41037279",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037279/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8747,7 +10210,9 @@
       "pmid": "41037295",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41037295/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8763,7 +10228,9 @@
       "pmid": "40884493",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40884493/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8779,7 +10246,9 @@
       "pmid": "40875572",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875572/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8795,7 +10264,9 @@
       "pmid": "41147986",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41147986/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8811,7 +10282,11 @@
       "pmid": "41147520",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41147520/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8827,7 +10302,9 @@
       "pmid": "40875216",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875216/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8843,7 +10320,9 @@
       "pmid": "40884491",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40884491/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8859,7 +10338,10 @@
       "pmid": "41151453",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41151453/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8875,7 +10357,9 @@
       "pmid": "41143927",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41143927/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8891,7 +10375,9 @@
       "pmid": "41144826",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41144826/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8907,7 +10393,9 @@
       "pmid": "41143807",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41143807/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8923,7 +10411,9 @@
       "pmid": "41143461",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41143461/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8939,7 +10429,9 @@
       "pmid": "41143434",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41143434/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8955,7 +10447,9 @@
       "pmid": "41144242",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41144242/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8971,7 +10465,9 @@
       "pmid": "41144815",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41144815/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -8987,7 +10483,10 @@
       "pmid": "41143389",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41143389/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9003,7 +10502,9 @@
       "pmid": "41143830",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41143830/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9019,7 +10520,9 @@
       "pmid": "41143832",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41143832/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9035,7 +10538,9 @@
       "pmid": "41143809",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41143809/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9051,7 +10556,9 @@
       "pmid": "41144245",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41144245/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9067,7 +10574,9 @@
       "pmid": "41143822",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41143822/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9083,7 +10592,10 @@
       "pmid": "41139237",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41139237/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9099,7 +10611,10 @@
       "pmid": "41138146",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41138146/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9115,7 +10630,11 @@
       "pmid": "41133918",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41133918/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9131,7 +10650,12 @@
       "pmid": "41133943",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41133943/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Salivary & Oral Cavity",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9147,7 +10671,9 @@
       "pmid": "41133279",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41133279/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9163,7 +10689,9 @@
       "pmid": "41134590",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134590/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9179,7 +10707,9 @@
       "pmid": "41134589",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134589/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9195,7 +10725,9 @@
       "pmid": "41138441",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41138441/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9211,7 +10743,9 @@
       "pmid": "41134584",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41134584/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9227,7 +10761,12 @@
       "pmid": "41133930",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41133930/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9243,7 +10782,11 @@
       "pmid": "41129161",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129161/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9259,7 +10802,9 @@
       "pmid": "41129160",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129160/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9275,7 +10820,12 @@
       "pmid": "41135212",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41135212/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9291,7 +10841,11 @@
       "pmid": "41126754",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41126754/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9307,7 +10861,9 @@
       "pmid": "41129120",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129120/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9323,7 +10879,9 @@
       "pmid": "41129139",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129139/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9339,7 +10897,9 @@
       "pmid": "41127944",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41127944/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9355,7 +10915,9 @@
       "pmid": "41129122",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129122/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9371,7 +10933,9 @@
       "pmid": "41129163",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129163/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9387,7 +10951,9 @@
       "pmid": "41129141",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129141/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9403,7 +10969,11 @@
       "pmid": "41127925",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41127925/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9419,7 +10989,9 @@
       "pmid": "41129174",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129174/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9435,7 +11007,9 @@
       "pmid": "41129143",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129143/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9451,7 +11025,9 @@
       "pmid": "41127932",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41127932/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9467,7 +11043,10 @@
       "pmid": "41129177",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129177/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9483,7 +11062,9 @@
       "pmid": "41129123",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129123/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9499,7 +11080,11 @@
       "pmid": "41128178",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41128178/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9515,7 +11100,9 @@
       "pmid": "41129137",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41129137/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9531,7 +11118,13 @@
       "pmid": "41130026",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41130026/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9547,7 +11140,10 @@
       "pmid": "41130027",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41130027/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9563,7 +11159,13 @@
       "pmid": "41130892",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41130892/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9579,7 +11181,9 @@
       "pmid": "41123923",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123923/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9595,7 +11199,9 @@
       "pmid": "41124062",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41124062/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9611,7 +11217,10 @@
       "pmid": "41123025",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123025/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9627,7 +11236,9 @@
       "pmid": "41124070",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41124070/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9643,7 +11254,11 @@
       "pmid": "41130028",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41130028/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Infectious Disease",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9659,7 +11274,11 @@
       "pmid": "41122999",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41122999/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9675,7 +11294,9 @@
       "pmid": "41123916",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123916/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9691,7 +11312,10 @@
       "pmid": "41123007",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123007/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9707,7 +11331,9 @@
       "pmid": "41123915",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123915/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9723,7 +11349,11 @@
       "pmid": "41124356",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41124356/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9739,7 +11369,10 @@
       "pmid": "41130891",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41130891/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9755,7 +11388,9 @@
       "pmid": "41123911",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41123911/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9771,7 +11406,10 @@
       "pmid": "41130890",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41130890/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9787,7 +11425,12 @@
       "pmid": "40674064",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40674064/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9803,7 +11446,11 @@
       "pmid": "41117768",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117768/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9819,7 +11466,9 @@
       "pmid": "40878848",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40878848/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9835,7 +11484,11 @@
       "pmid": "41117769",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117769/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9851,7 +11504,10 @@
       "pmid": "41117516",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117516/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9867,7 +11523,9 @@
       "pmid": "41117384",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117384/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9883,7 +11541,12 @@
       "pmid": "41124841",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41124841/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9899,7 +11562,9 @@
       "pmid": "41117370",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117370/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9915,7 +11580,10 @@
       "pmid": "41117299",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117299/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9931,7 +11599,9 @@
       "pmid": "41117848",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117848/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9947,7 +11617,9 @@
       "pmid": "41117849",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117849/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9963,7 +11635,9 @@
       "pmid": "40788641",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40788641/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9979,7 +11653,10 @@
       "pmid": "41117774",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117774/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -9995,7 +11672,9 @@
       "pmid": "41117850",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117850/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10011,7 +11690,9 @@
       "pmid": "41117365",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117365/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10027,7 +11708,11 @@
       "pmid": "41117789",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41117789/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10043,7 +11728,9 @@
       "pmid": "40833740",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40833740/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10059,7 +11746,9 @@
       "pmid": "40788628",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40788628/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10075,7 +11764,11 @@
       "pmid": "41111462",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41111462/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10091,7 +11784,9 @@
       "pmid": "41115002",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41115002/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10107,7 +11802,9 @@
       "pmid": "41114993",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41114993/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10123,7 +11820,10 @@
       "pmid": "41110384",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41110384/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10139,7 +11839,10 @@
       "pmid": "41110385",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41110385/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10155,7 +11858,13 @@
       "pmid": "41104796",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41104796/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10171,7 +11880,11 @@
       "pmid": "41108907",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41108907/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10187,7 +11900,9 @@
       "pmid": "41105422",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41105422/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10203,7 +11918,9 @@
       "pmid": "41105402",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41105402/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10219,7 +11936,11 @@
       "pmid": "41104810",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41104810/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10235,7 +11956,9 @@
       "pmid": "41105403",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41105403/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10251,7 +11974,9 @@
       "pmid": "41105577",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41105577/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10267,7 +11992,11 @@
       "pmid": "41108908",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41108908/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10283,7 +12012,9 @@
       "pmid": "41105404",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41105404/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10299,7 +12030,9 @@
       "pmid": "41105420",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41105420/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10315,7 +12048,9 @@
       "pmid": "41105421",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41105421/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10331,7 +12066,9 @@
       "pmid": "41107205",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41107205/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10347,7 +12084,9 @@
       "pmid": "41105413",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41105413/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10363,7 +12102,9 @@
       "pmid": "41105419",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41105419/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10379,7 +12120,12 @@
       "pmid": "41109787",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41109787/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10395,7 +12141,10 @@
       "pmid": "41100094",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100094/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10411,7 +12160,9 @@
       "pmid": "41100099",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100099/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10427,7 +12178,9 @@
       "pmid": "41100107",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100107/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10443,7 +12196,10 @@
       "pmid": "41100121",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100121/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10459,7 +12215,9 @@
       "pmid": "41100108",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100108/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10475,7 +12233,10 @@
       "pmid": "41100093",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100093/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10491,7 +12252,9 @@
       "pmid": "41100117",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100117/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10507,7 +12270,13 @@
       "pmid": "41099405",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41099405/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10523,7 +12292,11 @@
       "pmid": "41099387",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41099387/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10539,7 +12312,11 @@
       "pmid": "41100109",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100109/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10555,7 +12332,11 @@
       "pmid": "41100079",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100079/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10571,7 +12352,10 @@
       "pmid": "41100100",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100100/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10587,7 +12371,11 @@
       "pmid": "41100124",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41100124/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10603,7 +12391,9 @@
       "pmid": "41090702",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41090702/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10619,7 +12409,9 @@
       "pmid": "41091484",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091484/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10635,7 +12427,9 @@
       "pmid": "41091514",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091514/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10651,7 +12445,11 @@
       "pmid": "41091526",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091526/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10667,7 +12465,9 @@
       "pmid": "41091498",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091498/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10683,7 +12483,10 @@
       "pmid": "41091528",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091528/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10699,7 +12502,10 @@
       "pmid": "41091890",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091890/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10715,7 +12521,9 @@
       "pmid": "41091482",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091482/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10731,7 +12539,9 @@
       "pmid": "41091491",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091491/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10747,7 +12557,9 @@
       "pmid": "41091512",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41091512/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10763,7 +12575,9 @@
       "pmid": "40810946",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40810946/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10779,7 +12593,10 @@
       "pmid": "41088730",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41088730/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10795,7 +12612,9 @@
       "pmid": "40886075",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40886075/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10811,7 +12630,9 @@
       "pmid": "40886311",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40886311/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10827,7 +12648,10 @@
       "pmid": "41085095",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41085095/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10843,7 +12667,9 @@
       "pmid": "40875211",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875211/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10859,7 +12685,9 @@
       "pmid": "40886309",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40886309/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10875,7 +12703,10 @@
       "pmid": "40690248",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40690248/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10891,7 +12722,9 @@
       "pmid": "41085578",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41085578/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10907,7 +12740,11 @@
       "pmid": "41081462",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41081462/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Infectious Disease",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10923,7 +12760,9 @@
       "pmid": "41082196",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41082196/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10939,7 +12778,9 @@
       "pmid": "41082194",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41082194/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10955,7 +12796,10 @@
       "pmid": "41081473",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41081473/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10971,7 +12815,13 @@
       "pmid": "41087247",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41087247/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -10987,7 +12837,9 @@
       "pmid": "41082212",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41082212/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11003,7 +12855,11 @@
       "pmid": "41087248",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41087248/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11019,7 +12875,9 @@
       "pmid": "41081468",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41081468/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11035,7 +12893,9 @@
       "pmid": "41081455",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41081455/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11051,7 +12911,9 @@
       "pmid": "41082372",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41082372/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11067,7 +12929,9 @@
       "pmid": "41082187",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41082187/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11083,7 +12947,9 @@
       "pmid": "41082218",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41082218/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11099,7 +12965,9 @@
       "pmid": "41076587",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41076587/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11115,7 +12983,9 @@
       "pmid": "41076589",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41076589/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11131,7 +13001,9 @@
       "pmid": "41076588",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41076588/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11147,7 +13019,11 @@
       "pmid": "41074698",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41074698/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11163,7 +13039,9 @@
       "pmid": "41075281",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41075281/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11179,7 +13057,12 @@
       "pmid": "41074706",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41074706/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11195,7 +13078,11 @@
       "pmid": "41070633",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41070633/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11211,7 +13098,10 @@
       "pmid": "41076354",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41076354/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11227,7 +13117,10 @@
       "pmid": "41076353",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41076353/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11243,7 +13136,11 @@
       "pmid": "41070703",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41070703/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11259,7 +13156,10 @@
       "pmid": "41065188",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41065188/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11275,7 +13175,9 @@
       "pmid": "41066092",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41066092/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11291,7 +13193,9 @@
       "pmid": "41065647",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41065647/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11307,7 +13211,10 @@
       "pmid": "41069023",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41069023/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11323,7 +13230,9 @@
       "pmid": "41060621",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41060621/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11339,7 +13248,9 @@
       "pmid": "41060626",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41060626/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11355,7 +13266,9 @@
       "pmid": "41060628",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41060628/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11371,7 +13284,9 @@
       "pmid": "41060661",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41060661/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11387,7 +13302,11 @@
       "pmid": "41058606",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41058606/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11403,7 +13322,10 @@
       "pmid": "41059927",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41059927/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11419,7 +13341,9 @@
       "pmid": "41060627",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41060627/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11435,7 +13359,10 @@
       "pmid": "41059905",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41059905/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11451,7 +13378,9 @@
       "pmid": "41059564",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41059564/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11467,7 +13396,11 @@
       "pmid": "41059917",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41059917/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11483,7 +13416,11 @@
       "pmid": "41060922",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41060922/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11499,7 +13436,9 @@
       "pmid": "40853651",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40853651/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11515,7 +13454,9 @@
       "pmid": "40875215",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875215/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11531,7 +13472,9 @@
       "pmid": "41054944",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41054944/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11547,7 +13490,9 @@
       "pmid": "40658405",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40658405/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11563,7 +13508,9 @@
       "pmid": "40875202",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875202/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11579,7 +13526,12 @@
       "pmid": "41061455",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41061455/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11595,7 +13547,9 @@
       "pmid": "41055660",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41055660/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11611,7 +13565,9 @@
       "pmid": "41055657",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41055657/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11627,7 +13583,9 @@
       "pmid": "40864435",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40864435/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11643,7 +13601,11 @@
       "pmid": "41055227",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41055227/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Infectious Disease",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11659,7 +13621,9 @@
       "pmid": "41055661",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41055661/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11675,7 +13639,9 @@
       "pmid": "41055658",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41055658/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11691,7 +13657,9 @@
       "pmid": "40864438",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40864438/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11707,7 +13675,9 @@
       "pmid": "40853677",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40853677/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11723,7 +13693,9 @@
       "pmid": "40773212",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773212/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11739,7 +13711,9 @@
       "pmid": "40875242",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875242/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11755,7 +13729,9 @@
       "pmid": "40736371",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40736371/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11771,7 +13747,9 @@
       "pmid": "41055659",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41055659/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11787,7 +13765,12 @@
       "pmid": "41056766",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41056766/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11803,7 +13786,10 @@
       "pmid": "41048191",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41048191/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11819,7 +13805,10 @@
       "pmid": "41051123",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051123/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11835,7 +13824,10 @@
       "pmid": "41051759",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051759/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11851,7 +13843,12 @@
       "pmid": "41051015",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41051015/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11867,7 +13864,9 @@
       "pmid": "41053966",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41053966/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11883,7 +13882,11 @@
       "pmid": "41045125",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41045125/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11899,7 +13902,10 @@
       "pmid": "41045095",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41045095/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11915,7 +13921,9 @@
       "pmid": "41045292",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41045292/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11931,7 +13939,11 @@
       "pmid": "41045102",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41045102/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11947,7 +13959,11 @@
       "pmid": "41045113",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41045113/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11963,7 +13979,10 @@
       "pmid": "41045294",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41045294/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11979,7 +13998,11 @@
       "pmid": "41045117",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41045117/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -11995,7 +14018,12 @@
       "pmid": "41041862",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41041862/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12011,7 +14039,11 @@
       "pmid": "41041822",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41041822/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12027,7 +14059,10 @@
       "pmid": "41041955",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41041955/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12043,7 +14078,12 @@
       "pmid": "41035368",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41035368/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12059,7 +14099,9 @@
       "pmid": "40879521",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40879521/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12075,7 +14117,12 @@
       "pmid": "40481755",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40481755/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12091,7 +14138,11 @@
       "pmid": "40568791",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40568791/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12107,7 +14158,12 @@
       "pmid": "40481803",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40481803/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12123,7 +14179,9 @@
       "pmid": "40865387",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40865387/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12139,7 +14197,9 @@
       "pmid": "40497688",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40497688/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12155,7 +14215,9 @@
       "pmid": "40227955",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40227955/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12171,7 +14233,9 @@
       "pmid": "40736514",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40736514/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12187,7 +14251,12 @@
       "pmid": "40779854",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40779854/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12203,7 +14272,11 @@
       "pmid": "40530780",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40530780/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12219,7 +14292,9 @@
       "pmid": "40758246",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40758246/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12235,7 +14310,10 @@
       "pmid": "40485640",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40485640/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12251,7 +14329,12 @@
       "pmid": "40879607",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40879607/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12267,7 +14350,10 @@
       "pmid": "40840211",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40840211/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12283,7 +14369,9 @@
       "pmid": "40557780",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40557780/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12299,7 +14387,12 @@
       "pmid": "40371962",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40371962/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12315,7 +14408,11 @@
       "pmid": "40359321",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40359321/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12331,7 +14428,11 @@
       "pmid": "40387279",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40387279/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12347,7 +14448,13 @@
       "pmid": "40387265",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40387265/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12363,7 +14470,9 @@
       "pmid": "40879609",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40879609/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12379,7 +14488,11 @@
       "pmid": "39172002",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39172002/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12395,7 +14508,10 @@
       "pmid": "40600904",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40600904/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12411,7 +14527,10 @@
       "pmid": "40323191",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40323191/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12427,7 +14546,10 @@
       "pmid": "40586428",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40586428/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12443,7 +14565,9 @@
       "pmid": "40227970",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40227970/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12459,7 +14583,13 @@
       "pmid": "40326261",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40326261/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12475,7 +14605,11 @@
       "pmid": "40346847",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40346847/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12491,7 +14625,11 @@
       "pmid": "40384602",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40384602/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12507,7 +14645,13 @@
       "pmid": "40444945",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40444945/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12523,7 +14667,9 @@
       "pmid": "40856004",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40856004/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12539,7 +14685,10 @@
       "pmid": "40444406",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40444406/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12555,7 +14704,11 @@
       "pmid": "40876073",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40876073/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12571,7 +14724,10 @@
       "pmid": "40650558",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40650558/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12587,7 +14743,10 @@
       "pmid": "40293065",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40293065/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12603,7 +14762,10 @@
       "pmid": "40825084",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40825084/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12619,7 +14781,10 @@
       "pmid": "40384632",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40384632/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12635,7 +14800,9 @@
       "pmid": "40237602",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40237602/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12651,7 +14818,10 @@
       "pmid": "40387017",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40387017/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12667,7 +14837,9 @@
       "pmid": "40277459",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40277459/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12683,7 +14855,10 @@
       "pmid": "40278341",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40278341/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12699,7 +14874,11 @@
       "pmid": "40346843",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40346843/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12715,7 +14894,10 @@
       "pmid": "40548759",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40548759/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12731,7 +14913,11 @@
       "pmid": "40386824",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40386824/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12747,7 +14933,11 @@
       "pmid": "40353761",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40353761/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12763,7 +14953,12 @@
       "pmid": "40515521",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40515521/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12779,7 +14974,11 @@
       "pmid": "40344225",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40344225/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12795,7 +14994,12 @@
       "pmid": "40926452",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40926452/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12811,7 +15015,11 @@
       "pmid": "40342052",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40342052/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12827,7 +15035,12 @@
       "pmid": "40536310",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40536310/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12843,7 +15056,13 @@
       "pmid": "40346846",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40346846/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12859,7 +15078,13 @@
       "pmid": "40679114",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40679114/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12875,7 +15100,10 @@
       "pmid": "40492397",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40492397/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12891,7 +15119,10 @@
       "pmid": "40865388",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40865388/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12907,7 +15138,9 @@
       "pmid": "40497692",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40497692/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12923,7 +15156,10 @@
       "pmid": "40600912",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40600912/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12939,7 +15175,13 @@
       "pmid": "40907073",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40907073/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12955,7 +15197,9 @@
       "pmid": "40600893",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40600893/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12971,7 +15215,9 @@
       "pmid": "40439037",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40439037/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -12987,7 +15233,10 @@
       "pmid": "40342152",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40342152/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13003,7 +15252,10 @@
       "pmid": "40364730",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40364730/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13019,7 +15271,11 @@
       "pmid": "40444408",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40444408/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13035,7 +15291,11 @@
       "pmid": "40257263",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40257263/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13051,7 +15311,11 @@
       "pmid": "40227117",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40227117/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13067,7 +15331,13 @@
       "pmid": "40641301",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40641301/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13083,7 +15353,11 @@
       "pmid": "40912133",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40912133/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13099,7 +15373,10 @@
       "pmid": "40377211",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40377211/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13115,7 +15392,9 @@
       "pmid": "40782117",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40782117/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13131,7 +15410,10 @@
       "pmid": "40546126",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40546126/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13147,7 +15429,10 @@
       "pmid": "40912131",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40912131/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13163,7 +15448,10 @@
       "pmid": "40371996",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40371996/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13179,7 +15467,10 @@
       "pmid": "40298521",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40298521/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13195,7 +15486,11 @@
       "pmid": "40355346",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40355346/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13211,7 +15506,10 @@
       "pmid": "40323123",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40323123/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13227,7 +15525,10 @@
       "pmid": "40346862",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40346862/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13243,7 +15544,10 @@
       "pmid": "40511877",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40511877/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13259,7 +15563,10 @@
       "pmid": "40930941",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40930941/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13275,7 +15582,9 @@
       "pmid": "40840212",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40840212/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13291,7 +15600,10 @@
       "pmid": "40925776",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40925776/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13307,7 +15619,13 @@
       "pmid": "40497639",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40497639/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Sleep Medicine",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13323,7 +15641,11 @@
       "pmid": "40530770",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40530770/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13339,7 +15661,11 @@
       "pmid": "40401825",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40401825/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13355,7 +15681,11 @@
       "pmid": "40359314",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40359314/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13371,7 +15701,11 @@
       "pmid": "40650637",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40650637/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13387,7 +15721,11 @@
       "pmid": "40323157",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40323157/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13403,7 +15741,10 @@
       "pmid": "40600346",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40600346/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13419,7 +15760,10 @@
       "pmid": "40485641",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40485641/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13435,7 +15779,9 @@
       "pmid": "40810992",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40810992/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13451,7 +15797,9 @@
       "pmid": "40879887",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40879887/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13467,7 +15815,10 @@
       "pmid": "40277452",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40277452/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13483,7 +15834,9 @@
       "pmid": "40758285",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40758285/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13499,7 +15852,10 @@
       "pmid": "40396584",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40396584/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13515,7 +15871,9 @@
       "pmid": "40719035",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40719035/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13531,7 +15889,9 @@
       "pmid": "40546085",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40546085/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13547,7 +15907,11 @@
       "pmid": "40912132",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40912132/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13563,7 +15927,10 @@
       "pmid": "40536288",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40536288/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13579,7 +15946,11 @@
       "pmid": "40257275",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40257275/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13595,7 +15966,10 @@
       "pmid": "40346859",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40346859/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13611,7 +15985,10 @@
       "pmid": "40747720",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40747720/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13627,7 +16004,11 @@
       "pmid": "40481740",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40481740/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Infectious Disease",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13643,7 +16024,9 @@
       "pmid": "40879048",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40879048/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13659,7 +16042,9 @@
       "pmid": "40342158",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40342158/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13675,7 +16060,11 @@
       "pmid": "40355345",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40355345/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13691,7 +16080,10 @@
       "pmid": "40265744",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40265744/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13707,7 +16099,10 @@
       "pmid": "40387008",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40387008/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13723,7 +16118,10 @@
       "pmid": "40879266",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40879266/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13739,7 +16137,11 @@
       "pmid": "40439006",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40439006/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13755,7 +16157,10 @@
       "pmid": "40331800",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40331800/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13771,7 +16176,9 @@
       "pmid": "40935728",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40935728/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13787,7 +16194,9 @@
       "pmid": "40844498",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40844498/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13803,7 +16212,11 @@
       "pmid": "40371737",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40371737/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13819,7 +16232,10 @@
       "pmid": "40353737",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40353737/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13835,7 +16251,10 @@
       "pmid": "40492386",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40492386/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13851,7 +16270,9 @@
       "pmid": "40583601",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40583601/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13867,7 +16288,9 @@
       "pmid": "41032406",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032406/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13883,7 +16306,11 @@
       "pmid": "41030155",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41030155/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13899,7 +16326,10 @@
       "pmid": "40614254",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40614254/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13915,7 +16345,9 @@
       "pmid": "40728905",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40728905/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13931,7 +16363,9 @@
       "pmid": "40855751",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40855751/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13947,7 +16381,11 @@
       "pmid": "41030087",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41030087/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13963,7 +16401,13 @@
       "pmid": "40875240",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875240/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Salivary & Oral Cavity",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13979,7 +16423,9 @@
       "pmid": "41066119",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41066119/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -13995,7 +16441,9 @@
       "pmid": "40674772",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40674772/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14011,7 +16459,9 @@
       "pmid": "40839349",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839349/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14027,7 +16477,9 @@
       "pmid": "40875210",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875210/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14043,7 +16495,9 @@
       "pmid": "41032401",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032401/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14059,7 +16513,10 @@
       "pmid": "40720946",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40720946/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14075,7 +16532,9 @@
       "pmid": "40875225",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875225/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14091,7 +16550,10 @@
       "pmid": "40587119",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40587119/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14107,7 +16569,10 @@
       "pmid": "40875244",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875244/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14123,7 +16588,9 @@
       "pmid": "40875204",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875204/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14139,7 +16606,10 @@
       "pmid": "40875206",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875206/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14155,7 +16625,12 @@
       "pmid": "41030111",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41030111/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14171,7 +16646,11 @@
       "pmid": "40875219",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875219/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14187,7 +16666,10 @@
       "pmid": "40587156",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40587156/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14203,7 +16685,10 @@
       "pmid": "40875250",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875250/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14219,7 +16704,10 @@
       "pmid": "41035311",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41035311/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14235,7 +16723,9 @@
       "pmid": "40587092",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40587092/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14251,7 +16741,10 @@
       "pmid": "40820301",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40820301/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14267,7 +16760,9 @@
       "pmid": "41032289",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032289/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14283,7 +16778,10 @@
       "pmid": "40619980",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40619980/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14299,7 +16797,10 @@
       "pmid": "40657706",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40657706/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14315,7 +16816,10 @@
       "pmid": "40621839",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40621839/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14331,7 +16835,9 @@
       "pmid": "40587220",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40587220/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14347,7 +16853,9 @@
       "pmid": "41032314",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032314/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14363,7 +16871,10 @@
       "pmid": "41039690",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41039690/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14379,7 +16890,11 @@
       "pmid": "40839358",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839358/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14395,7 +16910,9 @@
       "pmid": "41032404",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032404/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14411,7 +16928,11 @@
       "pmid": "40820310",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40820310/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14427,7 +16948,9 @@
       "pmid": "41032306",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032306/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14443,7 +16966,10 @@
       "pmid": "40810987",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40810987/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14459,7 +16985,11 @@
       "pmid": "40839277",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839277/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14475,7 +17005,9 @@
       "pmid": "41032334",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032334/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14491,7 +17023,11 @@
       "pmid": "40810991",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40810991/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14507,7 +17043,10 @@
       "pmid": "41032290",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41032290/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14523,7 +17062,10 @@
       "pmid": "40657797",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40657797/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14539,7 +17081,12 @@
       "pmid": "41025561",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41025561/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14555,7 +17102,10 @@
       "pmid": "41026796",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41026796/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14571,7 +17121,12 @@
       "pmid": "41025540",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41025540/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14587,7 +17142,10 @@
       "pmid": "41025537",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41025537/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14603,7 +17161,10 @@
       "pmid": "41026592",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41026592/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14619,7 +17180,10 @@
       "pmid": "41026481",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41026481/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14635,7 +17199,10 @@
       "pmid": "41025243",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41025243/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14651,7 +17218,9 @@
       "pmid": "41017750",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41017750/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14667,7 +17236,11 @@
       "pmid": "41020290",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41020290/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14683,7 +17256,10 @@
       "pmid": "41017768",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41017768/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14699,7 +17275,10 @@
       "pmid": "41021400",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41021400/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14715,7 +17294,10 @@
       "pmid": "41014166",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41014166/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14731,7 +17313,13 @@
       "pmid": "41014165",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41014165/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14747,7 +17335,11 @@
       "pmid": "41014146",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41014146/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14763,7 +17355,10 @@
       "pmid": "41014176",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41014176/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14779,7 +17374,9 @@
       "pmid": "41004186",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004186/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14795,7 +17392,9 @@
       "pmid": "41004136",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004136/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14811,7 +17410,10 @@
       "pmid": "41015685",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41015685/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14827,7 +17429,9 @@
       "pmid": "41004143",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004143/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14843,7 +17447,9 @@
       "pmid": "41004139",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004139/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14859,7 +17465,9 @@
       "pmid": "41004141",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004141/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14875,7 +17483,10 @@
       "pmid": "41004123",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004123/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14891,7 +17502,9 @@
       "pmid": "41004171",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004171/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14907,7 +17520,11 @@
       "pmid": "41014990",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41014990/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14923,7 +17540,10 @@
       "pmid": "41014989",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41014989/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14939,7 +17559,9 @@
       "pmid": "41004138",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004138/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14955,7 +17577,9 @@
       "pmid": "41004178",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004178/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14971,7 +17595,10 @@
       "pmid": "41004908",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/41004908/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -14987,7 +17614,10 @@
       "pmid": "40995988",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40995988/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15003,7 +17633,12 @@
       "pmid": "40996731",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996731/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15019,7 +17654,10 @@
       "pmid": "40995940",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40995940/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15035,7 +17673,13 @@
       "pmid": "40995965",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40995965/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15051,7 +17695,11 @@
       "pmid": "40997227",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40997227/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Rhinology & Allergy",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15067,7 +17715,10 @@
       "pmid": "40996774",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996774/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15083,7 +17734,9 @@
       "pmid": "40996751",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996751/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15099,7 +17752,9 @@
       "pmid": "40995935",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40995935/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15115,7 +17770,10 @@
       "pmid": "40997254",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40997254/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15131,7 +17789,12 @@
       "pmid": "40995952",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40995952/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15147,7 +17810,9 @@
       "pmid": "40996758",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40996758/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15163,7 +17828,9 @@
       "pmid": "40990336",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40990336/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15179,7 +17846,13 @@
       "pmid": "40990262",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40990262/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15195,7 +17868,13 @@
       "pmid": "40998677",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40998677/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15211,7 +17890,9 @@
       "pmid": "40991282",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40991282/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15227,7 +17908,9 @@
       "pmid": "40991275",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40991275/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15243,7 +17926,10 @@
       "pmid": "40988571",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40988571/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15259,7 +17945,9 @@
       "pmid": "40991255",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40991255/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15275,7 +17963,10 @@
       "pmid": "40988606",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40988606/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15291,7 +17982,9 @@
       "pmid": "40853559",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40853559/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15307,7 +18000,9 @@
       "pmid": "40742715",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40742715/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15323,7 +18018,9 @@
       "pmid": "40839261",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839261/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15339,7 +18036,9 @@
       "pmid": "40728837",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40728837/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15355,7 +18054,9 @@
       "pmid": "40833742",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40833742/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15371,7 +18072,9 @@
       "pmid": "40986422",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40986422/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15387,7 +18090,9 @@
       "pmid": "40880110",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40880110/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15403,7 +18108,10 @@
       "pmid": "40773213",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773213/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15419,7 +18127,9 @@
       "pmid": "40844767",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40844767/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15435,7 +18145,9 @@
       "pmid": "40864437",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40864437/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15451,7 +18163,11 @@
       "pmid": "40985510",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40985510/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15467,7 +18183,10 @@
       "pmid": "40985511",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40985511/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15483,7 +18202,9 @@
       "pmid": "40844810",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40844810/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15499,7 +18220,9 @@
       "pmid": "40880114",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40880114/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15515,7 +18238,9 @@
       "pmid": "40864444",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40864444/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15531,7 +18256,9 @@
       "pmid": "40880080",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40880080/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15547,7 +18274,9 @@
       "pmid": "40839362",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839362/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15563,7 +18292,9 @@
       "pmid": "40844788",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40844788/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15579,7 +18310,9 @@
       "pmid": "40853561",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40853561/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15595,7 +18328,9 @@
       "pmid": "40875248",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875248/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15611,7 +18346,11 @@
       "pmid": "40985495",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40985495/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15627,7 +18366,9 @@
       "pmid": "40875241",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40875241/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15643,7 +18384,9 @@
       "pmid": "40986000",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40986000/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15659,7 +18402,9 @@
       "pmid": "40844806",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40844806/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15675,7 +18420,9 @@
       "pmid": "40844805",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40844805/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15691,7 +18438,9 @@
       "pmid": "40674074",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40674074/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15707,7 +18456,9 @@
       "pmid": "40880076",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40880076/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15723,7 +18474,9 @@
       "pmid": "40899949",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899949/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15739,7 +18492,9 @@
       "pmid": "40985071",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40985071/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15755,7 +18510,9 @@
       "pmid": "40880098",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40880098/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15771,7 +18528,9 @@
       "pmid": "40853650",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40853650/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15787,7 +18546,9 @@
       "pmid": "40864476",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40864476/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15803,7 +18564,9 @@
       "pmid": "40833759",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40833759/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15819,7 +18582,10 @@
       "pmid": "40985553",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40985553/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15835,7 +18601,9 @@
       "pmid": "40833750",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40833750/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15851,7 +18619,9 @@
       "pmid": "40864436",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40864436/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15867,7 +18637,11 @@
       "pmid": "40977566",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40977566/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15883,7 +18657,11 @@
       "pmid": "40984002",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40984002/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15899,7 +18677,11 @@
       "pmid": "40974152",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40974152/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15915,7 +18697,11 @@
       "pmid": "40974133",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40974133/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15931,7 +18717,9 @@
       "pmid": "40970361",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40970361/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15947,7 +18735,10 @@
       "pmid": "40971178",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40971178/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15963,7 +18754,9 @@
       "pmid": "40971177",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40971177/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15979,7 +18772,9 @@
       "pmid": "40971162",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40971162/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -15995,7 +18790,9 @@
       "pmid": "40971537",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40971537/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16011,7 +18808,10 @@
       "pmid": "40970441",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40970441/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16027,7 +18827,9 @@
       "pmid": "40971161",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40971161/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16043,7 +18845,9 @@
       "pmid": "40971153",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40971153/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16059,7 +18863,11 @@
       "pmid": "40970393",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40970393/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16075,7 +18883,9 @@
       "pmid": "40971173",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40971173/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16091,7 +18901,9 @@
       "pmid": "40971172",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40971172/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16107,7 +18919,9 @@
       "pmid": "40971174",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40971174/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16123,7 +18937,9 @@
       "pmid": "40965897",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965897/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16139,7 +18955,9 @@
       "pmid": "40965860",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965860/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16155,7 +18973,9 @@
       "pmid": "40965902",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965902/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16171,7 +18991,9 @@
       "pmid": "40965896",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965896/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16187,7 +19009,12 @@
       "pmid": "40964826",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40964826/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16203,7 +19030,9 @@
       "pmid": "40965893",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965893/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16219,7 +19048,9 @@
       "pmid": "40965874",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965874/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16235,7 +19066,9 @@
       "pmid": "40965867",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965867/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16251,7 +19084,9 @@
       "pmid": "40965898",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40965898/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16267,7 +19102,9 @@
       "pmid": "40960820",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960820/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16283,7 +19120,12 @@
       "pmid": "40960806",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960806/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Infectious Disease",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16299,7 +19141,13 @@
       "pmid": "40960120",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960120/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16315,7 +19163,9 @@
       "pmid": "40960844",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960844/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16331,7 +19181,12 @@
       "pmid": "40960129",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960129/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16347,7 +19202,9 @@
       "pmid": "40960842",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960842/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16363,7 +19220,10 @@
       "pmid": "40960144",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960144/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16379,7 +19239,10 @@
       "pmid": "40960821",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960821/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16395,7 +19258,9 @@
       "pmid": "40960800",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960800/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16411,7 +19276,9 @@
       "pmid": "40960851",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960851/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16427,7 +19294,9 @@
       "pmid": "40960823",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960823/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16443,7 +19312,9 @@
       "pmid": "40960850",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960850/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16459,7 +19330,12 @@
       "pmid": "40960150",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40960150/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16475,7 +19351,9 @@
       "pmid": "40773219",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773219/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16491,7 +19369,11 @@
       "pmid": "40955863",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40955863/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16507,7 +19389,9 @@
       "pmid": "40815509",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40815509/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16523,7 +19407,9 @@
       "pmid": "40788632",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40788632/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16539,7 +19425,10 @@
       "pmid": "40839372",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839372/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16555,7 +19444,11 @@
       "pmid": "40955969",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40955969/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16571,7 +19464,9 @@
       "pmid": "40815508",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40815508/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16587,7 +19482,9 @@
       "pmid": "40833679",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40833679/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16603,7 +19500,9 @@
       "pmid": "40815505",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40815505/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16619,7 +19518,9 @@
       "pmid": "40815507",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40815507/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16635,7 +19536,9 @@
       "pmid": "40956347",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40956347/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16651,7 +19554,9 @@
       "pmid": "40839364",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839364/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16667,7 +19572,9 @@
       "pmid": "40773214",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773214/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16683,7 +19590,9 @@
       "pmid": "40815503",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40815503/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16699,7 +19608,9 @@
       "pmid": "40839363",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839363/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16715,7 +19626,9 @@
       "pmid": "40788601",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40788601/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16731,7 +19644,9 @@
       "pmid": "40768233",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40768233/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16747,7 +19662,9 @@
       "pmid": "40815528",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40815528/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16763,7 +19680,9 @@
       "pmid": "40658525",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40658525/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16779,7 +19698,9 @@
       "pmid": "40839275",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839275/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16795,7 +19716,9 @@
       "pmid": "40788630",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40788630/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16811,7 +19734,9 @@
       "pmid": "40549398",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40549398/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16827,7 +19752,9 @@
       "pmid": "40736397",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40736397/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16843,7 +19770,9 @@
       "pmid": "40839278",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40839278/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16859,7 +19788,9 @@
       "pmid": "40768220",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40768220/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16875,7 +19806,9 @@
       "pmid": "40768158",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40768158/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16891,7 +19824,9 @@
       "pmid": "40815504",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40815504/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16907,7 +19842,9 @@
       "pmid": "40864452",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40864452/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16923,7 +19860,9 @@
       "pmid": "40815529",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40815529/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16939,7 +19878,11 @@
       "pmid": "40952730",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952730/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16955,7 +19898,9 @@
       "pmid": "40952747",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952747/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16971,7 +19916,9 @@
       "pmid": "40952732",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952732/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -16987,7 +19934,11 @@
       "pmid": "40948451",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40948451/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17003,7 +19954,11 @@
       "pmid": "40948436",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40948436/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17019,7 +19974,9 @@
       "pmid": "40952748",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952748/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17035,7 +19992,14 @@
       "pmid": "40948443",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40948443/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17051,7 +20015,9 @@
       "pmid": "40952866",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952866/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17067,7 +20033,9 @@
       "pmid": "40952854",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952854/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17083,7 +20051,9 @@
       "pmid": "40952711",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952711/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17099,7 +20069,9 @@
       "pmid": "40952721",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952721/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17115,7 +20087,10 @@
       "pmid": "40952065",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952065/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17131,7 +20106,9 @@
       "pmid": "40952725",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952725/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17147,7 +20124,9 @@
       "pmid": "40952765",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40952765/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17163,7 +20142,11 @@
       "pmid": "40944545",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40944545/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17179,7 +20162,10 @@
       "pmid": "40944537",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40944537/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17195,7 +20181,10 @@
       "pmid": "40944547",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40944547/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17211,7 +20200,11 @@
       "pmid": "40944542",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40944542/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17227,7 +20220,9 @@
       "pmid": "40944544",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40944544/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17243,7 +20238,9 @@
       "pmid": "40938612",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40938612/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17259,7 +20256,9 @@
       "pmid": "40937692",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40937692/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17275,7 +20274,9 @@
       "pmid": "40938604",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40938604/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17291,7 +20292,9 @@
       "pmid": "40938595",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40938595/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17307,7 +20310,9 @@
       "pmid": "40937494",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40937494/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17323,7 +20328,10 @@
       "pmid": "40938609",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40938609/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17339,7 +20347,9 @@
       "pmid": "40937489",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40937489/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17355,7 +20365,10 @@
       "pmid": "40937496",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40937496/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17371,7 +20384,9 @@
       "pmid": "40938607",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40938607/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17387,7 +20402,9 @@
       "pmid": "40938594",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40938594/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17403,7 +20420,9 @@
       "pmid": "40938593",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40938593/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17419,7 +20438,9 @@
       "pmid": "40938605",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40938605/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17435,7 +20456,9 @@
       "pmid": "40932317",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932317/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17451,7 +20474,9 @@
       "pmid": "40932710",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932710/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17467,7 +20492,9 @@
       "pmid": "40932712",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932712/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17483,7 +20510,9 @@
       "pmid": "40932705",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932705/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17499,7 +20528,10 @@
       "pmid": "40932734",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932734/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17515,7 +20547,9 @@
       "pmid": "40932304",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932304/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17531,7 +20565,9 @@
       "pmid": "40932315",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932315/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17547,7 +20583,9 @@
       "pmid": "40932711",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932711/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17563,7 +20601,9 @@
       "pmid": "40932314",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932314/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17579,7 +20619,9 @@
       "pmid": "40932709",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932709/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17595,7 +20637,9 @@
       "pmid": "40932439",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40932439/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17611,7 +20655,9 @@
       "pmid": "40928773",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40928773/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17627,7 +20673,9 @@
       "pmid": "40928800",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40928800/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17643,7 +20691,9 @@
       "pmid": "40928788",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40928788/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17659,7 +20709,9 @@
       "pmid": "40928805",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40928805/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17675,7 +20727,9 @@
       "pmid": "40928771",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40928771/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17691,7 +20745,9 @@
       "pmid": "40928804",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40928804/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17707,7 +20763,9 @@
       "pmid": "40928934",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40928934/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17723,7 +20781,9 @@
       "pmid": "40928795",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40928795/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17739,7 +20799,11 @@
       "pmid": "40928456",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40928456/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17755,7 +20819,9 @@
       "pmid": "40927953",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40927953/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17771,7 +20837,11 @@
       "pmid": "40923196",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40923196/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17787,7 +20857,9 @@
       "pmid": "40742703",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40742703/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17803,7 +20875,9 @@
       "pmid": "40779254",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40779254/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17819,7 +20893,10 @@
       "pmid": "40923568",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40923568/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17835,7 +20912,9 @@
       "pmid": "40768209",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40768209/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17851,7 +20930,9 @@
       "pmid": "40779294",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40779294/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17867,7 +20948,10 @@
       "pmid": "40923666",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40923666/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17883,7 +20967,9 @@
       "pmid": "40779293",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40779293/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17899,7 +20985,11 @@
       "pmid": "40788723",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40788723/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17915,7 +21005,11 @@
       "pmid": "40923621",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40923621/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17931,7 +21025,9 @@
       "pmid": "40779288",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40779288/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17947,7 +21043,10 @@
       "pmid": "40587168",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40587168/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17963,7 +21062,9 @@
       "pmid": "40601334",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40601334/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17979,7 +21080,9 @@
       "pmid": "40674060",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40674060/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -17995,7 +21098,9 @@
       "pmid": "40632549",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40632549/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18011,7 +21116,11 @@
       "pmid": "40923521",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40923521/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18027,7 +21136,9 @@
       "pmid": "40758324",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40758324/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18043,7 +21154,9 @@
       "pmid": "40638112",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40638112/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18059,7 +21172,9 @@
       "pmid": "40779274",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40779274/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18075,7 +21190,9 @@
       "pmid": "40638108",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40638108/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18091,7 +21208,9 @@
       "pmid": "40736727",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40736727/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18107,7 +21226,9 @@
       "pmid": "40737020",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40737020/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18123,7 +21244,9 @@
       "pmid": "40768160",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40768160/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18139,7 +21262,9 @@
       "pmid": "40773192",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773192/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18155,7 +21280,9 @@
       "pmid": "40788629",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40788629/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18171,7 +21298,9 @@
       "pmid": "40779291",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40779291/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18187,7 +21316,9 @@
       "pmid": "40773173",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773173/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18203,7 +21334,9 @@
       "pmid": "40779261",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40779261/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18219,7 +21352,9 @@
       "pmid": "40742600",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40742600/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18235,7 +21370,9 @@
       "pmid": "40779289",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40779289/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18251,7 +21388,9 @@
       "pmid": "40768234",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40768234/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18267,7 +21406,9 @@
       "pmid": "40773184",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773184/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18283,7 +21424,11 @@
       "pmid": "40923567",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40923567/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18299,7 +21444,9 @@
       "pmid": "40924058",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40924058/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18315,7 +21462,9 @@
       "pmid": "40758376",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40758376/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18331,7 +21480,11 @@
       "pmid": "40923216",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40923216/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18347,7 +21500,9 @@
       "pmid": "40768216",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40768216/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18363,7 +21518,11 @@
       "pmid": "40919819",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40919819/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18379,7 +21538,9 @@
       "pmid": "40920401",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40920401/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18395,7 +21556,9 @@
       "pmid": "40920372",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40920372/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18411,7 +21574,10 @@
       "pmid": "40919750",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40919750/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18427,7 +21593,9 @@
       "pmid": "40920409",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40920409/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18443,7 +21611,9 @@
       "pmid": "40920367",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40920367/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18459,7 +21629,9 @@
       "pmid": "40920411",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40920411/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18475,7 +21647,14 @@
       "pmid": "40919831",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40919831/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18491,7 +21670,11 @@
       "pmid": "40910720",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40910720/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18507,7 +21690,9 @@
       "pmid": "40911313",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911313/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18523,7 +21708,9 @@
       "pmid": "40911333",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911333/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18539,7 +21726,10 @@
       "pmid": "40911371",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911371/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18555,7 +21745,9 @@
       "pmid": "40911303",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911303/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18571,7 +21763,9 @@
       "pmid": "40910694",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40910694/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18587,7 +21781,9 @@
       "pmid": "40911319",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911319/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18603,7 +21799,9 @@
       "pmid": "40911318",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911318/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18619,7 +21817,9 @@
       "pmid": "40911320",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911320/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18635,7 +21835,9 @@
       "pmid": "40911314",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911314/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18651,7 +21853,9 @@
       "pmid": "40911316",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911316/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18667,7 +21871,11 @@
       "pmid": "40910741",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40910741/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18683,7 +21891,9 @@
       "pmid": "40911321",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911321/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18699,7 +21909,11 @@
       "pmid": "40910734",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40910734/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18715,7 +21929,9 @@
       "pmid": "40911332",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40911332/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18731,7 +21947,9 @@
       "pmid": "40906490",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906490/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18747,7 +21965,12 @@
       "pmid": "40906519",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906519/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18763,7 +21986,9 @@
       "pmid": "40906492",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906492/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18779,7 +22004,9 @@
       "pmid": "40906482",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906482/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18795,7 +22022,9 @@
       "pmid": "40906551",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906551/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18811,7 +22040,9 @@
       "pmid": "40906466",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906466/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18827,7 +22058,11 @@
       "pmid": "40906481",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906481/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18843,7 +22078,10 @@
       "pmid": "40906539",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906539/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18859,7 +22097,10 @@
       "pmid": "40906486",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906486/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18875,7 +22116,10 @@
       "pmid": "40906474",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906474/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18891,7 +22135,9 @@
       "pmid": "40906468",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906468/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18907,7 +22153,9 @@
       "pmid": "40906494",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906494/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18923,7 +22171,10 @@
       "pmid": "40906487",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906487/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18939,7 +22190,10 @@
       "pmid": "40906513",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906513/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18955,7 +22209,9 @@
       "pmid": "40906495",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906495/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18971,7 +22227,9 @@
       "pmid": "40906472",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906472/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -18987,7 +22245,9 @@
       "pmid": "40906484",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906484/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19003,7 +22263,10 @@
       "pmid": "40906531",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906531/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19019,7 +22282,11 @@
       "pmid": "40906473",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906473/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19035,7 +22302,9 @@
       "pmid": "40906488",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40906488/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19051,7 +22320,11 @@
       "pmid": "40899662",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899662/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19067,7 +22340,9 @@
       "pmid": "40900610",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40900610/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19083,7 +22358,9 @@
       "pmid": "40900608",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40900608/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19099,7 +22376,9 @@
       "pmid": "40900609",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40900609/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19115,7 +22394,11 @@
       "pmid": "40899481",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899481/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19131,7 +22414,9 @@
       "pmid": "40900552",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40900552/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19147,7 +22432,9 @@
       "pmid": "40900584",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40900584/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19163,7 +22450,12 @@
       "pmid": "40899420",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899420/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19179,7 +22471,10 @@
       "pmid": "40900603",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40900603/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19195,7 +22490,10 @@
       "pmid": "40899436",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899436/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19211,7 +22509,10 @@
       "pmid": "40899385",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899385/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19227,7 +22528,11 @@
       "pmid": "40899454",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899454/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19243,7 +22548,11 @@
       "pmid": "40899650",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899650/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19259,7 +22568,11 @@
       "pmid": "40899474",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899474/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19275,7 +22588,12 @@
       "pmid": "40899433",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40899433/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19291,7 +22609,9 @@
       "pmid": "40900579",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40900579/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19307,7 +22627,9 @@
       "pmid": "40900575",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40900575/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19323,7 +22645,9 @@
       "pmid": "40748644",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40748644/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19339,7 +22663,10 @@
       "pmid": "40758374",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40758374/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19355,7 +22682,9 @@
       "pmid": "40773344",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773344/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19371,7 +22700,9 @@
       "pmid": "40748538",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40748538/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19387,7 +22718,9 @@
       "pmid": "40720100",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40720100/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19403,7 +22736,9 @@
       "pmid": "40720233",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40720233/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19419,7 +22754,10 @@
       "pmid": "40891559",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40891559/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19435,7 +22773,9 @@
       "pmid": "40748539",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40748539/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19451,7 +22791,9 @@
       "pmid": "40773186",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773186/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19467,7 +22809,9 @@
       "pmid": "40720104",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40720104/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19483,7 +22827,9 @@
       "pmid": "40773217",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773217/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19499,7 +22845,9 @@
       "pmid": "40728838",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40728838/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19515,7 +22863,9 @@
       "pmid": "40720102",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40720102/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19531,7 +22881,10 @@
       "pmid": "40758342",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40758342/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19547,7 +22900,9 @@
       "pmid": "40690211",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40690211/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19563,7 +22918,9 @@
       "pmid": "40773205",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773205/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19579,7 +22936,10 @@
       "pmid": "40891562",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40891562/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19595,7 +22955,10 @@
       "pmid": "40658396",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40658396/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19611,7 +22974,9 @@
       "pmid": "40748633",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40748633/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19627,7 +22992,9 @@
       "pmid": "40748630",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40748630/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19643,7 +23010,10 @@
       "pmid": "40758331",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40758331/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19659,7 +23029,9 @@
       "pmid": "40440165",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40440165/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19675,7 +23047,9 @@
       "pmid": "40720141",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40720141/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19691,7 +23065,10 @@
       "pmid": "40758323",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40758323/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19707,7 +23084,9 @@
       "pmid": "40728833",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40728833/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19723,7 +23102,10 @@
       "pmid": "40193249",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40193249/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19739,7 +23121,9 @@
       "pmid": "40728786",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40728786/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19755,7 +23139,9 @@
       "pmid": "40748622",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40748622/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19771,7 +23157,9 @@
       "pmid": "40748628",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40748628/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19787,7 +23175,9 @@
       "pmid": "40569588",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40569588/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19803,7 +23193,9 @@
       "pmid": "40748532",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40748532/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19819,7 +23211,9 @@
       "pmid": "40720101",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40720101/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19835,7 +23229,9 @@
       "pmid": "40720148",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40720148/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "General ENT/Other"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19851,7 +23247,12 @@
       "pmid": "40342151",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40342151/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19867,7 +23268,12 @@
       "pmid": "40293041",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40293041/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19883,7 +23289,12 @@
       "pmid": "40265713",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40265713/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19899,7 +23310,10 @@
       "pmid": "40310165",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40310165/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19915,7 +23329,10 @@
       "pmid": "39237389",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39237389/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19931,7 +23348,12 @@
       "pmid": "40285656",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40285656/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19947,7 +23369,12 @@
       "pmid": "40514298",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40514298/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19963,7 +23390,10 @@
       "pmid": "40388707",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40388707/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19979,7 +23409,9 @@
       "pmid": "40344493",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40344493/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -19995,7 +23427,10 @@
       "pmid": "40342167",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40342167/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20011,7 +23446,9 @@
       "pmid": "40444418",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40444418/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20027,7 +23464,12 @@
       "pmid": "40202247",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40202247/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20043,7 +23485,11 @@
       "pmid": "40323179",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40323179/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20059,7 +23505,11 @@
       "pmid": "40260735",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40260735/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20075,7 +23525,12 @@
       "pmid": "40186507",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40186507/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20091,7 +23546,12 @@
       "pmid": "40504089",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40504089/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20107,7 +23567,9 @@
       "pmid": "40462619",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40462619/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20123,7 +23585,10 @@
       "pmid": "40191971",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40191971/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20139,7 +23604,9 @@
       "pmid": "40298540",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40298540/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20155,7 +23622,10 @@
       "pmid": "40227995",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40227995/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20171,7 +23641,10 @@
       "pmid": "40265672",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40265672/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20187,7 +23660,9 @@
       "pmid": "40195790",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40195790/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20203,7 +23678,10 @@
       "pmid": "40342045",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40342045/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20219,7 +23697,9 @@
       "pmid": "40237567",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40237567/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20235,7 +23715,11 @@
       "pmid": "40285663",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40285663/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20251,7 +23735,9 @@
       "pmid": "40521839",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40521839/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20267,7 +23753,14 @@
       "pmid": "39701873",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39701873/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20283,7 +23776,12 @@
       "pmid": "40227884",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40227884/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20299,7 +23797,11 @@
       "pmid": "39414522",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39414522/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20315,7 +23817,10 @@
       "pmid": "40265743",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40265743/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20331,7 +23836,11 @@
       "pmid": "40396632",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40396632/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20347,7 +23856,11 @@
       "pmid": "40326273",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40326273/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20363,7 +23876,11 @@
       "pmid": "40016006",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40016006/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20379,7 +23896,11 @@
       "pmid": "40285653",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40285653/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20395,7 +23916,11 @@
       "pmid": "40866210",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40866210/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20411,7 +23936,10 @@
       "pmid": "40257302",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40257302/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20427,7 +23955,11 @@
       "pmid": "40323129",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40323129/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20443,7 +23975,9 @@
       "pmid": "40353781",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40353781/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20459,7 +23993,11 @@
       "pmid": "39414523",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39414523/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20475,7 +24013,11 @@
       "pmid": "40116368",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40116368/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20491,7 +24033,11 @@
       "pmid": "40231759",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40231759/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20507,7 +24053,11 @@
       "pmid": "40342186",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40342186/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20523,7 +24073,9 @@
       "pmid": "40237563",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40237563/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20539,7 +24091,12 @@
       "pmid": "40057433",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40057433/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20555,7 +24112,11 @@
       "pmid": "40227144",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40227144/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20571,7 +24132,11 @@
       "pmid": "40237479",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40237479/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20587,7 +24152,10 @@
       "pmid": "40329591",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40329591/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20603,7 +24171,9 @@
       "pmid": "40323143",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40323143/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20619,7 +24189,10 @@
       "pmid": "40553102",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40553102/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20635,7 +24208,10 @@
       "pmid": "40309961",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40309961/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20651,7 +24227,13 @@
       "pmid": "40411300",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40411300/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20667,7 +24249,10 @@
       "pmid": "40421885",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40421885/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20683,7 +24268,11 @@
       "pmid": "40299896",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40299896/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20699,7 +24288,9 @@
       "pmid": "40135762",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40135762/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20715,7 +24306,10 @@
       "pmid": "40342043",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40342043/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20731,7 +24325,10 @@
       "pmid": "40326464",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40326464/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20747,7 +24344,12 @@
       "pmid": "40816986",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40816986/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20763,7 +24365,10 @@
       "pmid": "40227110",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40227110/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Pediatrics"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20779,7 +24384,10 @@
       "pmid": "40388718",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40388718/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20795,7 +24403,11 @@
       "pmid": "40237581",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40237581/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20811,7 +24423,11 @@
       "pmid": "40243090",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40243090/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20827,7 +24443,9 @@
       "pmid": "40504098",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40504098/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20843,7 +24461,10 @@
       "pmid": "40183781",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40183781/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20859,7 +24480,10 @@
       "pmid": "40317750",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40317750/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20875,7 +24499,11 @@
       "pmid": "40166908",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40166908/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20891,7 +24519,9 @@
       "pmid": "40265717",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40265717/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20907,7 +24537,12 @@
       "pmid": "40879615",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40879615/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Head & Neck Oncology",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20923,7 +24558,10 @@
       "pmid": "40135727",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40135727/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20939,7 +24577,9 @@
       "pmid": "40444400",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40444400/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20955,7 +24595,9 @@
       "pmid": "40320766",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40320766/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20971,7 +24613,9 @@
       "pmid": "40757986",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40757986/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -20987,7 +24631,12 @@
       "pmid": "40421845",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40421845/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21003,7 +24652,13 @@
       "pmid": "40130528",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40130528/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Salivary & Oral Cavity",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21019,7 +24674,10 @@
       "pmid": "40135771",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40135771/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21035,7 +24693,10 @@
       "pmid": "40298464",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40298464/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21051,7 +24712,9 @@
       "pmid": "40318034",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40318034/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21067,7 +24730,13 @@
       "pmid": "40202220",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40202220/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21083,7 +24752,10 @@
       "pmid": "39984347",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39984347/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21099,7 +24771,10 @@
       "pmid": "40257287",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40257287/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21115,7 +24790,10 @@
       "pmid": "40304255",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40304255/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21131,7 +24809,10 @@
       "pmid": "40130430",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40130430/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21147,7 +24828,10 @@
       "pmid": "40560640",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40560640/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21163,7 +24847,10 @@
       "pmid": "40387027",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40387027/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21179,7 +24866,10 @@
       "pmid": "40243062",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40243062/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21195,7 +24885,10 @@
       "pmid": "40825097",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40825097/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21211,7 +24904,10 @@
       "pmid": "40481798",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40481798/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21227,7 +24923,10 @@
       "pmid": "40237535",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40237535/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21243,7 +24942,11 @@
       "pmid": "39658500",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39658500/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21259,7 +24962,9 @@
       "pmid": "40396596",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40396596/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21275,7 +24980,11 @@
       "pmid": "40326260",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40326260/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21291,7 +25000,11 @@
       "pmid": "40119770",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40119770/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Audiology & Hearing Science",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21307,7 +25020,10 @@
       "pmid": "39701874",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/39701874/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21323,7 +25039,11 @@
       "pmid": "40368122",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40368122/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Rhinology & Allergy",
+        "Skull Base & Cranial",
+        "Trauma"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21339,7 +25059,15 @@
       "pmid": "40371987",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40371987/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Salivary & Oral Cavity",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21355,7 +25083,11 @@
       "pmid": "40186513",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40186513/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21371,7 +25103,10 @@
       "pmid": "40145621",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40145621/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21387,7 +25122,10 @@
       "pmid": "40272223",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40272223/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21403,7 +25141,9 @@
       "pmid": "40119752",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40119752/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21419,7 +25159,9 @@
       "pmid": "40231755",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40231755/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21435,7 +25177,10 @@
       "pmid": "40421832",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40421832/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21451,7 +25196,11 @@
       "pmid": "40227129",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40227129/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21467,7 +25216,11 @@
       "pmid": "40257454",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40257454/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21483,7 +25236,10 @@
       "pmid": "40253235",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40253235/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21499,7 +25255,13 @@
       "pmid": "40888487",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40888487/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Facial Plastics & Reconstruction",
+        "Otology & Neurotology",
+        "Pediatrics",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21515,7 +25277,10 @@
       "pmid": "40742740",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40742740/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21531,7 +25296,9 @@
       "pmid": "40888556",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40888556/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21547,7 +25314,11 @@
       "pmid": "40888615",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40888615/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21563,7 +25334,9 @@
       "pmid": "40888519",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40888519/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21579,7 +25352,11 @@
       "pmid": "40773189",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773189/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Rhinology & Allergy",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21595,7 +25372,10 @@
       "pmid": "40674045",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40674045/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Sleep Medicine"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21611,7 +25391,9 @@
       "pmid": "40742579",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40742579/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21627,7 +25409,10 @@
       "pmid": "40887995",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40887995/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Infectious Disease",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21643,7 +25428,10 @@
       "pmid": "40742737",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40742737/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice",
+        "Otology & Neurotology"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21659,7 +25447,9 @@
       "pmid": "40674043",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40674043/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21675,7 +25465,9 @@
       "pmid": "40773187",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773187/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21691,7 +25483,11 @@
       "pmid": "40674073",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40674073/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Salivary & Oral Cavity"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21707,7 +25503,9 @@
       "pmid": "40888472",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40888472/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21723,7 +25521,9 @@
       "pmid": "40888606",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40888606/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21739,7 +25539,12 @@
       "pmid": "40674091",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40674091/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Head & Neck Oncology",
+        "Laryngology & Voice",
+        "Otology & Neurotology",
+        "Rhinology & Allergy"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21755,7 +25560,12 @@
       "pmid": "40888869",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40888869/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Airway & Trachea",
+        "Otology & Neurotology",
+        "Rhinology & Allergy",
+        "Skull Base & Cranial"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21771,7 +25581,11 @@
       "pmid": "40773204",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773204/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Head & Neck Oncology",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
@@ -21787,11 +25601,13 @@
       "pmid": "40773211",
       "pdf": "https://pubmed.ncbi.nlm.nih.gov/40773211/",
       "notes": "",
-      "subjects": [],
+      "subjects": [
+        "Endocrine (Thyroid/Parathyroid)",
+        "Laryngology & Voice"
+      ],
       "highlight": false,
       "analysis": "",
       "images": []
     }
-  ],
-  "monthly_summaries": []
+  ]
 }

--- a/data/subject_summary.json
+++ b/data/subject_summary.json
@@ -1,0 +1,53 @@
+{
+  "2025-09": {
+    "Laryngology & Voice": 183,
+    "General ENT/Other": 162,
+    "Otology & Neurotology": 133,
+    "Rhinology & Allergy": 98,
+    "Head & Neck Oncology": 58,
+    "Facial Plastics & Reconstruction": 36,
+    "Airway & Trachea": 28,
+    "Pediatrics": 23,
+    "Infectious Disease": 21,
+    "Sleep Medicine": 17,
+    "Trauma": 17,
+    "Skull Base & Cranial": 13,
+    "Audiology & Hearing Science": 12,
+    "Salivary & Oral Cavity": 11,
+    "Endocrine (Thyroid/Parathyroid)": 9
+  },
+  "2025-10": {
+    "Laryngology & Voice": 211,
+    "Otology & Neurotology": 127,
+    "Rhinology & Allergy": 126,
+    "General ENT/Other": 101,
+    "Head & Neck Oncology": 52,
+    "Airway & Trachea": 31,
+    "Pediatrics": 29,
+    "Facial Plastics & Reconstruction": 26,
+    "Sleep Medicine": 17,
+    "Infectious Disease": 16,
+    "Trauma": 14,
+    "Salivary & Oral Cavity": 13,
+    "Endocrine (Thyroid/Parathyroid)": 11,
+    "Audiology & Hearing Science": 11,
+    "Skull Base & Cranial": 7
+  },
+  "2025-11": {
+    "Laryngology & Voice": 206,
+    "General ENT/Other": 157,
+    "Otology & Neurotology": 129,
+    "Rhinology & Allergy": 126,
+    "Head & Neck Oncology": 60,
+    "Pediatrics": 26,
+    "Facial Plastics & Reconstruction": 24,
+    "Airway & Trachea": 21,
+    "Sleep Medicine": 19,
+    "Salivary & Oral Cavity": 15,
+    "Endocrine (Thyroid/Parathyroid)": 14,
+    "Trauma": 13,
+    "Infectious Disease": 12,
+    "Audiology & Hearing Science": 12,
+    "Skull Base & Cranial": 8
+  }
+}

--- a/tag_subjects.py
+++ b/tag_subjects.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+DATA_PATH = Path("data/journal_club.json")
+SUMMARY_PATH = Path("data/subject_summary.json")
+
+
+@dataclass(frozen=True)
+class SubjectRule:
+    name: str
+    patterns: Iterable[re.Pattern]
+
+    def matches(self, text: str) -> bool:
+        return any(pattern.search(text) for pattern in self.patterns)
+
+
+def compile_rules() -> List[SubjectRule]:
+    raw_rules = {
+        "Rhinology & Allergy": [
+            r"rhino",
+            r"sinus",
+            r"nasal",
+            r"nose",
+            r"septum",
+            r"polyp",
+            r"olfact",
+            r"smell",
+            r"sinonasal",
+            r"nasophary",
+            r"epistaxis",
+        ],
+        "Otology & Neurotology": [
+            r"cochlea",
+            r"ear",
+            r"otic",
+            r"tympan",
+            r"mastoid",
+            r"ossicul",
+            r"vestib",
+            r"tinnitus",
+            r"hearing",
+            r"ossicular",
+            r"otos",
+            r"eustachian",
+        ],
+        "Audiology & Hearing Science": [
+            r"audiology",
+            r"audiogram",
+            r"speech perception",
+            r"listening",
+            r"hearing aid",
+            r"cochlear implant",
+        ],
+        "Laryngology & Voice": [
+            r"laryn",
+            r"vocal cord",
+            r"voice",
+            r"phonation",
+            r"glott",
+            r"dysphonia",
+            r"esophag",
+        ],
+        "Airway & Trachea": [
+            r"airway",
+            r"trache",
+            r"bronch",
+            r"intubat",
+            r"decann",
+            r"stent",
+        ],
+        "Sleep Medicine": [
+            r"sleep",
+            r"apnea",
+            r"hypopnea",
+            r"cpap",
+            r"osa\b",
+        ],
+        "Head & Neck Oncology": [
+            r"carcinoma",
+            r"cancer",
+            r"tumou?r",
+            r"neoplasm",
+            r"sarcoma",
+            r"oncology",
+            r"malignan",
+            r"papilloma",
+        ],
+        "Endocrine (Thyroid/Parathyroid)": [
+            r"thyroid",
+            r"parathy",
+            r"endocrine",
+        ],
+        "Salivary & Oral Cavity": [
+            r"salivar",
+            r"parotid",
+            r"submandibular",
+            r"sublingual",
+            r"sialo",
+            r"oral cavity",
+            r"tongue",
+            r"palate",
+            r"tonsil",
+        ],
+        "Facial Plastics & Reconstruction": [
+            r"facial",
+            r"reconstruct",
+            r"rhinoplast",
+            r"cleft",
+            r"aesthe",
+            r"cosmetic",
+            r"flap",
+            r"graft",
+            r"scar",
+        ],
+        "Skull Base & Cranial": [
+            r"skull base",
+            r"cranial",
+            r"intracran",
+            r"cerebrospinal",
+            r"csf",
+            r"pituitar",
+            r"meningioma",
+        ],
+        "Trauma": [
+            r"trauma",
+            r"fracture",
+            r"injur",
+            r"gunshot",
+            r"laceration",
+        ],
+        "Infectious Disease": [
+            r"infect",
+            r"viral",
+            r"bacterial",
+            r"fungal",
+            r"abscess",
+            r"mycobacter",
+            r"sepsis",
+        ],
+    }
+    return [SubjectRule(name, [re.compile(pat, re.IGNORECASE) for pat in patterns]) for name, patterns in raw_rules.items()]
+
+
+SUBJECT_RULES = compile_rules()
+PEDIATRIC_PATTERN = re.compile(r"\b(pediatric|child|children|infant|neonate|adolesc|toddler|newborn)\b", re.IGNORECASE)
+
+
+def load_sessions():
+    with DATA_PATH.open() as f:
+        return json.load(f)["sessions"]
+
+
+def assign_subjects(text: str) -> List[str]:
+    matches = [rule.name for rule in SUBJECT_RULES if rule.matches(text)]
+    if PEDIATRIC_PATTERN.search(text):
+        matches.append("Pediatrics")
+
+    if not matches:
+        matches.append("General ENT/Other")
+
+    return sorted(set(matches))
+
+
+def update_sessions(sessions):
+    for session in sessions:
+        text = " ".join(
+            filter(
+                None,
+                [
+                    session.get("title", ""),
+                    session.get("journal", ""),
+                    session.get("abstract", ""),
+                    session.get("notes", ""),
+                ],
+            )
+        )
+        session["subjects"] = assign_subjects(text)
+
+
+def write_output(sessions):
+    data = {"sessions": sessions}
+    with DATA_PATH.open("w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    by_month: defaultdict[str, Counter] = defaultdict(Counter)
+    for session in sessions:
+        date = session.get("date", "")
+        month = date[:7] if date else "unknown"
+        for subject in session.get("subjects", []):
+            by_month[month][subject] += 1
+
+    summary = {month: dict(counter.most_common()) for month, counter in sorted(by_month.items())}
+    with SUMMARY_PATH.open("w") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def main():
+    sessions = load_sessions()
+    update_sessions(sessions)
+    write_output(sessions)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a keyword-based tagging script to classify recent journal club sessions and generate monthly subject summaries
- populate session data with derived subject tags and provide an aggregated subject summary file
- document the heuristics and how to rerun the tagging process

## Testing
- python tag_subjects.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e73665748328937a2c5172533767)