### PR TITLE
Fix ent harvest automation chain

### DIFF
--- a/.github/workflows/ent-harvest.yml
+++ b/.github/workflows/ent-harvest.yml
@@ -56,9 +56,11 @@ jobs:
           fi
 
       - name: Create ENT harvest pull request
+        id: cpr
+        continue-on-error: true
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ENT_HARVEST_TOKEN != '' && secrets.ENT_HARVEST_TOKEN || github.token }}
           commit-message: "ENT harvest: ${{ env.OUT_DIR }}"
           branch: ent-harvest/${{ env.OUT_DIR }}
           title: "ENT harvest: ${{ env.OUT_DIR }}"
@@ -66,6 +68,11 @@ jobs:
             Monthly ENT harvest outputs for ${{ env.OUT_DIR }}.
           add-paths: |
             ${{ env.OUT_DIR }}/
+
+      - name: Warn when pull request creation fails
+        if: steps.cpr.outcome == 'failure'
+        run: |
+          echo "::warning::Unable to create PR automatically. Ensure the repository allows GitHub Actions to open pull requests or provide an ENT_HARVEST_TOKEN secret with pull_request scope."
 
 
       - name: Upload artifacts (backup, even if nothing new to commit)

--- a/.github/workflows/populate-sessions.yml
+++ b/.github/workflows/populate-sessions.yml
@@ -14,19 +14,33 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Determine target branch
+        id: branch
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=main" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.branch }}
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Run populate_sessions.py
-        run: python populate_sessions.py
+      - name: Run populate_sessions.py and rebuild data
+        run: |
+          python populate_sessions.py
+          python build_journal_club.py
 
       - name: Commit updated sessions.csv
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add sessions.csv
+          git add sessions.csv data/journal_club.json
           git commit -m "Auto-populate sessions.csv from latest ent_all_results" || exit 0
-          git push
+          git push origin HEAD:${{ steps.branch.outputs.branch }}


### PR DESCRIPTION
## Summary
- add fallback token and warning for ENT harvest PR creation to avoid failures when GitHub Actions cannot open PRs
- ensure populate-sessions workflow works on ENT harvest branches, rebuilds data, and pushes updates to the same branch

## Testing
- python -m compileall populate_sessions.py build_journal_club.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695651b34f048328bd6da58fe0f5f108)