### PR TITLE
Improve workflow resiliency for harvest and data rebuilds

### DIFF
--- a/.github/workflows/build-jc.yml
+++ b/.github/workflows/build-jc.yml
@@ -1,6 +1,9 @@
 name: Build journal club data
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     - cron: "0 5 1 * *"
   workflow_dispatch:
@@ -8,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ent-harvest.yml
+++ b/.github/workflows/ent-harvest.yml
@@ -63,25 +63,78 @@ jobs:
         run: |
           if [ -n "$ENT_HARVEST_TOKEN" ]; then
             echo "token=$ENT_HARVEST_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "Using ENT_HARVEST_TOKEN for pull request creation."
+            echo "target_branch=main" >> "$GITHUB_OUTPUT"
+            echo "create_pr=false" >> "$GITHUB_OUTPUT"
+            echo "Using ENT_HARVEST_TOKEN for direct pushes to main."
           else
             echo "token=$GITHUB_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "target_branch=ent-harvest/${{ env.OUT_DIR }}" >> "$GITHUB_OUTPUT"
+            echo "create_pr=true" >> "$GITHUB_OUTPUT"
             echo "::notice::ENT_HARVEST_TOKEN not provided; falling back to GITHUB_TOKEN. Ensure repository settings allow GitHub Actions to create pull requests."
           fi
 
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Push directly to main when permitted
+        id: direct-push
+        if: steps.select-token.outputs.create_pr == 'false'
+        env:
+          TOKEN: ${{ steps.select-token.outputs.token }}
+          TARGET_BRANCH: ${{ steps.select-token.outputs.target_branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git fetch origin "$DEFAULT_BRANCH"
+          git checkout -B "$TARGET_BRANCH" "origin/$DEFAULT_BRANCH"
+
+          git add "$OUT_DIR"
+
+          if git diff --cached --quiet; then
+            echo "No harvest outputs to commit."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "ENT harvest: $OUT_DIR"
+          git push "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}" "$TARGET_BRANCH"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
       - name: Create ENT harvest pull request
         id: cpr
+        if: steps.select-token.outputs.create_pr == 'true'
         continue-on-error: true
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.select-token.outputs.token }}
           commit-message: "ENT harvest: ${{ env.OUT_DIR }}"
-          branch: ent-harvest/${{ env.OUT_DIR }}
+          branch: ${{ steps.select-token.outputs.target_branch }}
           title: "ENT harvest: ${{ env.OUT_DIR }}"
           body: |
             Monthly ENT harvest outputs for ${{ env.OUT_DIR }}.
           add-paths: |
             ${{ env.OUT_DIR }}/
+
+      - name: Push harvest branch when PR creation fails
+        if: steps.select-token.outputs.create_pr == 'true' && steps.cpr.outcome == 'failure'
+        env:
+          TOKEN: ${{ steps.select-token.outputs.token }}
+          TARGET_BRANCH: ${{ steps.select-token.outputs.target_branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git fetch origin "$DEFAULT_BRANCH"
+          git checkout -B "$TARGET_BRANCH" "origin/$DEFAULT_BRANCH"
+
+          git add "$OUT_DIR"
+
+          if git diff --cached --quiet; then
+            echo "::warning::No harvest outputs found to push after PR failure."
+            exit 0
+          fi
+
+          git commit -m "ENT harvest: $OUT_DIR"
+          git push --force-with-lease "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}" "$TARGET_BRANCH"
 
       - name: Warn when pull request creation fails
         if: steps.cpr.outcome == 'failure'

--- a/.github/workflows/populate-sessions.yml
+++ b/.github/workflows/populate-sessions.yml
@@ -2,6 +2,9 @@ name: Populate sessions
 
 on:
   workflow_dispatch: {}  # allow manual runs
+  push:
+    branches:
+      - 'ent-harvest/**'
   workflow_run:
     workflows: ["ENT harvest (stage 1–2)"]
     types:
@@ -19,6 +22,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             echo "branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
             echo "branch=main" >> $GITHUB_OUTPUT
           fi
@@ -28,16 +33,32 @@ jobs:
           ref: ${{ steps.branch.outputs.branch }}
           fetch-depth: 0
 
+      - name: Verify fresh harvest data is present
+        id: harvest-check
+        run: |
+          HARVEST_FILE=$(rg --files -g "ent_all_results.json" | head -n 1 || true)
+
+          if [ -z "$HARVEST_FILE" ]; then
+            echo "::notice::No ent_all_results.json files found on ${{ steps.branch.outputs.branch }}; skipping population."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Found harvest data at $HARVEST_FILE"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Run populate_sessions.py and rebuild data
+        if: steps.harvest-check.outputs.found == 'true'
         run: |
           python populate_sessions.py
           python build_journal_club.py
 
       - name: Commit updated sessions.csv
+        if: steps.harvest-check.outputs.found == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- allow ENT harvest jobs to push directly to `main` with a PAT and fall back to pushing the harvest branch when PR creation fails
- trigger and gate session population on available `ent_all_results.json` outputs
- ensure scheduled data builds also run on pushes to `main` while avoiding workflow loops

## Testing
- not run (CI workflow changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69565a09e1cc8328bd275fbdee998c6e)