### PR TITLE
Fail runs when harvest returns no PMIDs

### DIFF
--- a/articlesRetrieval.ipynb
+++ b/articlesRetrieval.ipynb
@@ -142,7 +142,9 @@
     "]\n",
     "\n",
     "LOOKBACK_DAYS = 30\n",
-    "OUTPUT_DIR = os.path.join(\"data\", \"ent_search\")\n"
+    "OUTPUT_DIR = os.path.join(\"data\", \"ent_search\")\n",
+    "\n",
+    "ALLOW_EMPTY_HARVEST = os.getenv(\"ALLOW_EMPTY_HARVEST\", \"false\").lower() == \"true\"\n"
    ],
    "metadata": {
     "id": "gzIuu6HoBSym"
@@ -410,7 +412,11 @@
     "\n",
     "    if not pmid_list:\n",
     "        print(\"\u274c No articles found matching the criteria.\")\n",
-    "        return\n",
+    "        print(f\"Summary: discovered {len(pmid_list)} PMIDs between {start_date} and {end_date}.\")\n",
+    "        if ALLOW_EMPTY_HARVEST:\n",
+    "            print(\"\u26a0\ufe0f  Empty harvest allowed via ALLOW_EMPTY_HARVEST flag; exiting without failure.\")\n",
+    "            return\n",
+    "        raise RuntimeError(\"No articles found for the configured search window.\")\n",
     "\n",
     "    seen_pmids_path = os.path.join(OUTPUT_DIR, \"seen_pmids.json\")\n",
     "    seen_pmids = load_seen_pmids(seen_pmids_path)\n",
@@ -421,8 +427,12 @@
     "    print(f\"PMIDs to fetch after filtering seen set: {len(new_pmids)}\")\n",
     "\n",
     "    if not new_pmids:\n",
-    "        print(\"\u2705 No new PMIDs to process within this window.\")\n",
-    "        return\n",
+    "        print(\"\u26a0\ufe0f  No new PMIDs to process within this window.\")\n",
+    "        print(f\"Summary: discovered {len(pmid_list)} PMIDs, seen {len(seen_pmids)}, new {len(new_pmids)} between {start_date} and {end_date}.\")\n",
+    "        if ALLOW_EMPTY_HARVEST:\n",
+    "            print(\"\u26a0\ufe0f  Empty harvest allowed via ALLOW_EMPTY_HARVEST flag; exiting without failure.\")\n",
+    "            return\n",
+    "        raise RuntimeError(\"No new PMIDs to process after filtering seen set.\")\n",
     "\n",
     "    # Fetch article details\n",
     "    print(f\"\\n\ud83d\udcd6 Fetching details for {len(new_pmids)} new articles...\")\n",


### PR DESCRIPTION
## Summary
- add an ALLOW_EMPTY_HARVEST flag to optionally allow empty harvests during manual runs
- raise explicit runtime errors when no PMIDs are found or when only previously-seen PMIDs are returned, with added log summaries for troubleshooting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958e49e3e408328b0c4d8b754bb633c)