### PR TITLE
Add parameters tag to notebook configuration cell

### DIFF
--- a/articlesRetrieval.ipynb
+++ b/articlesRetrieval.ipynb
@@ -120,7 +120,10 @@
     "ALLOW_EMPTY_HARVEST = os.getenv(\"ALLOW_EMPTY_HARVEST\", \"false\").lower() == \"true\"\n"
    ],
    "metadata": {
-    "id": "gzIuu6HoBSym"
+    "id": "gzIuu6HoBSym",
+    "tags": [
+     "parameters"
+    ]
    },
    "execution_count": null,
    "outputs": []


### PR DESCRIPTION
## Summary
- add Papermill-compatible `parameters` tag to the configuration cell defining harvest inputs
- ensure ENT harvest workflow parameters can populate notebook variables

## Testing
- papermill articlesRetrieval.ipynb /tmp/output.ipynb -p TARGET_MONTH 2025-01 *(fails: papermill not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69591226badc8328b91a708a30840642)