### PR TITLE
Remove unsupported datetime_is_numeric usage

### DIFF
--- a/2025/12/articlesRetrieval.out.ipynb
+++ b/2025/12/articlesRetrieval.out.ipynb
@@ -105,8 +105,8 @@
      "output_type": "stream",
      "text": [
       "Downloading biopython-1.86-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (3.2 MB)\r\n",
-      "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/3.2 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.2/3.2 MB\u001b[0m \u001b[31m166.0 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0m\r\n",
+      "\u001b[?25l   \u001b[90m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[32m0.0/3.2 MB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r",
+      "\u001b[2K   \u001b[90m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[32m3.2/3.2 MB\u001b[0m \u001b[31m166.0 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0m\r\n",
       "\u001b[?25h"
      ]
     },
@@ -156,22 +156,22 @@
    "source": [
     "# Instructions for use\n",
     "\n",
-    "📋 INSTRUCTIONS:\n",
+    "\ud83d\udccb INSTRUCTIONS:\n",
     "\n",
     "1. Update the EMAIL variable with your email address (required by NCBI)\n",
     "2. Adjust JOURNALS and LOOKBACK_DAYS to shape the search window\n",
     "3. Run the cells to execute main() and harvest only new PMIDs within the rolling window or the requested month\n",
     "\n",
-    "⚠️  IMPORTANT NOTES:\n",
+    "\u26a0\ufe0f  IMPORTANT NOTES:\n",
     "\n",
-    "- Use your real email address - it’s required by NCBI’s usage policy\n",
-    "- Journal names should match PubMed’s format exactly\n",
+    "- Use your real email address - it\u2019s required by NCBI\u2019s usage policy\n",
+    "- Journal names should match PubMed\u2019s format exactly\n",
     "- Large queries may take several minutes to complete\n",
     "- Be respectful of API rate limits\n",
     "- Previously harvested PMIDs are stored in data/ent_search/seen_pmids.json to avoid duplicates\n",
     "- When running via GitHub Actions, you can supply TARGET_MONTH (YYYY-MM) or YEAR + MONTH inputs to rerun a specific calendar month instead of the rolling LOOKBACK_DAYS window.\n",
     "\n",
-    "🚀 To start, run: main()\n"
+    "\ud83d\ude80 To start, run: main()\n"
    ]
   },
   {
@@ -203,13 +203,13 @@
     "JOURNALS = [\n",
     "    \"International Forum of Allergy & Rhinology\",\n",
     "    \"Rhinology\",\n",
-    "    \"JAMA Otolaryngology–Head & Neck Surgery\",\n",
-    "    \"Otolaryngology–Head and Neck Surgery\",\n",
-    "    \"European Annals of Otorhinolaryngology–Head and Neck Diseases\",\n",
+    "    \"JAMA Otolaryngology\u2013Head & Neck Surgery\",\n",
+    "    \"Otolaryngology\u2013Head and Neck Surgery\",\n",
+    "    \"European Annals of Otorhinolaryngology\u2013Head and Neck Diseases\",\n",
     "    \"Journal of Voice\",\n",
     "    \"American Journal of Rhinology & Allergy\",\n",
-    "    \"JARO – Journal of the Association for Research in Otolaryngology\",\n",
-    "    \"Journal of Otolaryngology–Head & Neck Surgery\",\n",
+    "    \"JARO \u2013 Journal of the Association for Research in Otolaryngology\",\n",
+    "    \"Journal of Otolaryngology\u2013Head & Neck Surgery\",\n",
     "    \"Laryngoscope\",\n",
     "    \"Auris Nasus Larynx\",\n",
     "    \"new england journal of medicine\",\n",
@@ -287,7 +287,7 @@
     "                if isinstance(data, list):\n",
     "                    return set(map(str, data))\n",
     "        except Exception as exc:\n",
-    "            print(f\"⚠️  Could not load seen PMIDs: {exc}\")\n",
+    "            print(f\"\u26a0\ufe0f  Could not load seen PMIDs: {exc}\")\n",
     "    return set()\n",
     "\n",
     "\n",
@@ -409,7 +409,7 @@
     "                handle.close()\n",
     "\n",
     "                if not record or \"PubmedArticle\" not in record:\n",
-    "                    print(f\"⚠️  No article data found for PMID: {pmid}\")\n",
+    "                    print(f\"\u26a0\ufe0f  No article data found for PMID: {pmid}\")\n",
     "                    continue\n",
     "\n",
     "                article = record[\"PubmedArticle\"][0]\n",
@@ -499,7 +499,7 @@
     "\n",
     "    # Validate email\n",
     "    if EMAIL == \"your.email@example.com\":\n",
-    "        print(\"⚠️  Please update the EMAIL variable with your actual email address!\")\n",
+    "        print(\"\u26a0\ufe0f  Please update the EMAIL variable with your actual email address!\")\n",
     "        print(\"This is required by NCBI's API usage policy.\")\n",
     "        return\n",
     "\n",
@@ -507,7 +507,7 @@
     "    fetcher = PubMedFetcher(EMAIL)\n",
     "\n",
     "    # Search for articles within the requested window\n",
-    "    print(\"🔍 Searching for articles...\")\n",
+    "    print(\"\ud83d\udd0d Searching for articles...\")\n",
     "    pmid_list, start_date, end_date = fetcher.search_articles(\n",
     "        JOURNALS,\n",
     "        LOOKBACK_DAYS,\n",
@@ -516,10 +516,10 @@
     "    )\n",
     "\n",
     "    if not pmid_list:\n",
-    "        print(\"❌ No articles found matching the criteria.\")\n",
+    "        print(\"\u274c No articles found matching the criteria.\")\n",
     "        print(f\"Summary: discovered {len(pmid_list)} PMIDs between {start_date} and {end_date}.\")\n",
     "        if ALLOW_EMPTY_HARVEST:\n",
-    "            print(\"⚠️  Empty harvest allowed via ALLOW_EMPTY_HARVEST flag; exiting without failure.\")\n",
+    "            print(\"\u26a0\ufe0f  Empty harvest allowed via ALLOW_EMPTY_HARVEST flag; exiting without failure.\")\n",
     "            return\n",
     "        raise RuntimeError(\"No articles found for the configured search window.\")\n",
     "\n",
@@ -532,26 +532,26 @@
     "    print(f\"PMIDs to fetch after filtering seen set: {len(new_pmids)}\")\n",
     "\n",
     "    if not new_pmids:\n",
-    "        print(\"⚠️  No new PMIDs to process within this window.\")\n",
+    "        print(\"\u26a0\ufe0f  No new PMIDs to process within this window.\")\n",
     "        print(f\"Summary: discovered {len(pmid_list)} PMIDs, seen {len(seen_pmids)}, new {len(new_pmids)} between {start_date} and {end_date}.\")\n",
     "        if ALLOW_EMPTY_HARVEST:\n",
-    "            print(\"⚠️  Empty harvest allowed via ALLOW_EMPTY_HARVEST flag; exiting without failure.\")\n",
+    "            print(\"\u26a0\ufe0f  Empty harvest allowed via ALLOW_EMPTY_HARVEST flag; exiting without failure.\")\n",
     "            return\n",
     "        raise RuntimeError(\"No new PMIDs to process after filtering seen set.\")\n",
     "\n",
     "    # Fetch article details\n",
-    "    print(f\"📖 Fetching details for {len(new_pmids)} new articles...\")\n",
+    "    print(f\"\ud83d\udcd6 Fetching details for {len(new_pmids)} new articles...\")\n",
     "    articles = fetcher.fetch_article_details(new_pmids)\n",
     "\n",
     "    if not articles:\n",
-    "        print(\"❌ Failed to fetch article details.\")\n",
+    "        print(\"\u274c Failed to fetch article details.\")\n",
     "        return\n",
     "\n",
     "    # Create DataFrame\n",
     "    df = pd.DataFrame(articles)\n",
     "\n",
     "    # Display results\n",
-    "    print(f\"✅ Successfully retrieved {len(articles)} articles!\")\n",
+    "    print(f\"\u2705 Successfully retrieved {len(articles)} articles!\")\n",
     "    print(f\"Columns: {', '.join(df.columns.tolist())}\")\n",
     "\n",
     "    # Show first few rows\n",
@@ -572,16 +572,16 @@
     "    df.to_json(json_path, orient=\"records\", force_ascii=False, indent=2)\n",
     "\n",
     "    # Display summary statistics\n",
-    "    print(f\"📊 Summary:\")\n",
+    "    print(f\"\ud83d\udcca Summary:\")\n",
     "    print(f\"Total new articles: {len(articles)}\")\n",
     "    print(f\"Unique journals: {df['Journal'].nunique()}\")\n",
     "    print(f\"Articles per journal:\")\n",
     "    journal_counts = df['Journal'].value_counts()\n",
     "    for journal, count in journal_counts.head(10).items():\n",
-    "        print(f\"  • {journal}: {count}\")\n",
+    "        print(f\"  \u2022 {journal}: {count}\")\n",
     "\n",
-    "    print(f\"💾 Raw CSV saved to: {csv_path}\")\n",
-    "    print(f\"💾 ENT results JSON saved to: {json_path}\")\n",
+    "    print(f\"\ud83d\udcbe Raw CSV saved to: {csv_path}\")\n",
+    "    print(f\"\ud83d\udcbe ENT results JSON saved to: {json_path}\")\n",
     "\n",
     "    return df\n"
    ]
@@ -668,12 +668,12 @@
      "text": [
       "=== PubMed Journal Article Fetcher ===\n",
       "Email: shvecht@gmail.com\n",
-      "Journals: International Forum of Allergy & Rhinology, Rhinology, JAMA Otolaryngology–Head & Neck Surgery, Otolaryngology–Head and Neck Surgery, European Annals of Otorhinolaryngology–Head and Neck Diseases, Journal of Voice, American Journal of Rhinology & Allergy, JARO – Journal of the Association for Research in Otolaryngology, Journal of Otolaryngology–Head & Neck Surgery, Laryngoscope, Auris Nasus Larynx, new england journal of medicine, JAMA\n",
+      "Journals: International Forum of Allergy & Rhinology, Rhinology, JAMA Otolaryngology\u2013Head & Neck Surgery, Otolaryngology\u2013Head and Neck Surgery, European Annals of Otorhinolaryngology\u2013Head and Neck Diseases, Journal of Voice, American Journal of Rhinology & Allergy, JARO \u2013 Journal of the Association for Research in Otolaryngology, Journal of Otolaryngology\u2013Head & Neck Surgery, Laryngoscope, Auris Nasus Larynx, new england journal of medicine, JAMA\n",
       "--------------------------------------------------\n",
       "Requested month window: 2025-12-01 to 2025-12-31 (from TARGET_MONTH/TARGET_YEAR+TARGET_MONTH_NUMBER)\n",
       "--------------------------------------------------\n",
-      "🔍 Searching for articles...\n",
-      "Querying PubMed with: (\"International Forum of Allergy & Rhinology\"[Journal] OR \"Rhinology\"[Journal] OR \"JAMA Otolaryngology–Head & Neck Surgery\"[Journal] OR \"Otolaryngology–Head and Neck Surgery\"[Journal] OR \"European Annals of Otorhinolaryngology–Head and Neck Diseases\"[Journal] OR \"Journal of Voice\"[Journal] OR \"American Journal of Rhinology & Allergy\"[Journal] OR \"JARO – Journal of the Association for Research in Otolaryngology\"[Journal] OR \"Journal of Otolaryngology–Head & Neck Surgery\"[Journal] OR \"Laryngoscope\"[Journal] OR \"Auris Nasus Larynx\"[Journal] OR \"new england journal of medicine\"[Journal] OR \"JAMA\"[Journal]) AND (2025/12/01[PDAT] : 2025/12/31[PDAT])\n"
+      "\ud83d\udd0d Searching for articles...\n",
+      "Querying PubMed with: (\"International Forum of Allergy & Rhinology\"[Journal] OR \"Rhinology\"[Journal] OR \"JAMA Otolaryngology\u2013Head & Neck Surgery\"[Journal] OR \"Otolaryngology\u2013Head and Neck Surgery\"[Journal] OR \"European Annals of Otorhinolaryngology\u2013Head and Neck Diseases\"[Journal] OR \"Journal of Voice\"[Journal] OR \"American Journal of Rhinology & Allergy\"[Journal] OR \"JARO \u2013 Journal of the Association for Research in Otolaryngology\"[Journal] OR \"Journal of Otolaryngology\u2013Head & Neck Surgery\"[Journal] OR \"Laryngoscope\"[Journal] OR \"Auris Nasus Larynx\"[Journal] OR \"new england journal of medicine\"[Journal] OR \"JAMA\"[Journal]) AND (2025/12/01[PDAT] : 2025/12/31[PDAT])\n"
      ]
     },
     {
@@ -682,7 +682,7 @@
      "text": [
       "Found 533 articles\n",
       "PMIDs to fetch after filtering seen set: 533\n",
-      "📖 Fetching details for 533 new articles...\n"
+      "\ud83d\udcd6 Fetching details for 533 new articles...\n"
      ]
     },
     {
@@ -690,7 +690,7 @@
      "output_type": "stream",
      "text": [
       "Error parsing article: Remote end closed connection without response\n",
-      "❌ Failed to fetch article details.\n"
+      "\u274c Failed to fetch article details.\n"
      ]
     }
    ],
@@ -699,7 +699,7 @@
     "df = main()\n",
     "if df is not None:\n",
     "    print(\"=== DataFrame Summary ===\")\n",
-    "    print(df.describe(include='all', datetime_is_numeric=True))\n"
+    "    print(df.describe(include='all'))\n"
    ]
   }
  ],

--- a/articlesRetrieval.ipynb
+++ b/articlesRetrieval.ipynb
@@ -496,7 +496,7 @@
     "df = main()\n",
     "if df is not None:\n",
     "    print(\"=== DataFrame Summary ===\")\n",
-    "    print(df.describe(include='all', datetime_is_numeric=True))\n"
+    "    print(df.describe(include='all'))\n"
    ],
    "metadata": {
     "id": "xAVY_hYgpk5c"


### PR DESCRIPTION
## Summary
- remove the datetime_is_numeric argument when describing dataframes to support the current pandas version
- update the executed notebook copy for the December 2025 ENT harvest run to match the change

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695914d70bb08328bd9080485ecc54b2)